### PR TITLE
ui: Badge creation criteria glitches

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,7 +35,8 @@
 							"node_modules/@concentricsky/badgr-style/dist/css/screen.css",
 							"node_modules/dialog-polyfill/dialog-polyfill.css",
 							"src/breakdown/static/css/re-style.css",
-							"node_modules/maplibre-gl/dist/maplibre-gl.css"
+							"node_modules/maplibre-gl/dist/maplibre-gl.css",
+                            "node_modules/ngx-markdown-editor/assets/highlight.js/agate.min.css"
 						],
 						"scripts": [
 							"node_modules/ngx-markdown-editor/assets/highlight.js/highlight.min.js",

--- a/src/app/common/components/formfield-markdown.css
+++ b/src/app/common/components/formfield-markdown.css
@@ -1,4 +1,4 @@
-@import "~bootstrap/dist/css/bootstrap.css"
-@import "~ace-builds/css/ace.css"
-@import "~font-awesome/css/font-awesome.css"
-@import "~ngx-markdown-editor/assets/highlight.js/agate.min.css"
+@import "~bootstrap/dist/css/bootstrap.css";
+@import "~ace-builds/css/ace.css";
+@import "~font-awesome/css/font-awesome.css";
+/* Note that the agate.min.css style from the ngx-markdown-editor package is imported in angular.json, since it's not exported by the package and thus can't be imported here like this (only with a relative path, and that's not very clean) */

--- a/widgets-webpack.config.ts
+++ b/widgets-webpack.config.ts
@@ -18,14 +18,25 @@ const config: webpack.Configuration = {
 			{
 				test: /\.(png|jpg|gif|svg)$/i,
 				loader: 'url-loader'
-			}
+			},
+            {
+                test: /\.css$/,
+                use: ExtractTextPlugin.extract({
+                    use: [
+                        {
+                            loader: 'css-loader',
+                            options: {
+                                url: false
+                            }
+                        }
+                    ]
+                })
+            }
 		]
 	},
 	resolve: {
-		extensions: ['.ts'],
-        alias: {
-            '~': path.resolve('./node_modules')
-        }
+		extensions: ['.ts', '.css'],
+        modules: ['node_modules'],
 	},
 	output: {
 		filename: 'widgets.bundle.js',

--- a/widgets-webpack.config.ts
+++ b/widgets-webpack.config.ts
@@ -18,20 +18,7 @@ const config: webpack.Configuration = {
 			{
 				test: /\.(png|jpg|gif|svg)$/i,
 				loader: 'url-loader'
-			},
-            {
-                test: /\.css$/,
-                use: ExtractTextPlugin.extract({
-                    use: [
-                        {
-                            loader: 'css-loader',
-                            options: {
-                                url: false
-                            }
-                        }
-                    ]
-                })
-            }
+			}
 		]
 	},
 	resolve: {


### PR DESCRIPTION
The main changes necessary were to add semicolons to the imported style sheet and to move the ngx-markdown-editor style import to the angular.json file (as also suggested
[here](https://www.npmjs.com/package/ngx-markdown-editor#usage)), since it's not exported by the package.