### PR TITLE
ui: Getting logged out when searching for an image

### DIFF
--- a/src/app/common/components/formfield-image.ts
+++ b/src/app/common/components/formfield-image.ts
@@ -257,7 +257,7 @@ export class BgFormFieldImageComponent {
 			.then((icon: NounProjectIcon) => {
 				if (icon) {
 					this.generated = false;
-					this.updateFile(icon.preview_url);
+					this.updateFile(icon.thumbnail_url);
 				}
 			})
 			.catch((error) => {

--- a/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
+++ b/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.html
@@ -52,7 +52,7 @@
 															width="40"
 															[loading-src]="badgeLoadingImageUrl"
 															[error-src]="badgeFailedImageUrl"
-															[loaded-src]="icon.preview_url"
+															[loaded-src]="icon.thumbnail_url"
 														/> 
 														<p
 															class="u-text-bold u-text-breakword"

--- a/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.ts
+++ b/src/app/common/dialogs/nounproject-dialog/nounproject-dialog.component.ts
@@ -94,6 +94,7 @@ export class NounprojectDialog extends BaseDialog implements AfterViewInit {
 								result.tag_slugs = tag_slugs
 							})
 							this.icons = results;
+                            console.log("icons: " + results);
 							if (results.length < 10) { // currently we only request 10 at a time, but this could be changed in the server
 								this.endOfResults = true;
 							}

--- a/src/app/common/model/nounproject.model.ts
+++ b/src/app/common/model/nounproject.model.ts
@@ -9,9 +9,7 @@ export interface NounProjectIcon {
     license_description: string;
 	nounji_free: string;
 	permalink: string;
-	preview_url: string;
-	preview_url_42: string;
-	preview_url_84: string;
+	thumbnail_url: string;
 	sponsor: string;
 	sponsor_campaign_link: string | null;
     sponsor_id: string;


### PR DESCRIPTION
Use thenounproject API v2 in ui to reflect changes from the server. This is necessary since v1 is deprecated and not accessible for new users anymore.