### PR TITLE
UI: add npm test to GitHub check

### DIFF
--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -2,7 +2,7 @@ name: 🏗️ Build and publish to Github Container Registry
 
 on:
   push:
-    branches: [main,ui-add-npm-test-to-github-check]
+    branches: [main]
     tags: ["v*.*.*"]
   pull_request:
     branches:

--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -2,7 +2,7 @@ name: 🏗️ Build and publish to Github Container Registry
 
 on:
   push:
-    branches: [main]
+    branches: [main,ui-add-npm-test-to-github-check]
     tags: ["v*.*.*"]
   pull_request:
     branches:

--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -13,6 +13,30 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    name: 🧪 Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.9.0]
+
+    steps:
+      - name: ⬇️  Checkout repository
+        uses: actions/checkout@v4.1.1
+      - name: 🔨 Setup node
+        uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: 📲 Install dependencies
+        run: |
+          npm install
+          npm clean-install
+      - name: 📝 Test
+        run: |
+          npm run build
+          npm run test
+    
+
   build-and-push-image:
     name: 🏗️ Build and publish
     runs-on: ubuntu-latest
@@ -21,7 +45,7 @@ jobs:
       packages: write
 
     steps:
-      - name: ⬇️ Checkout repository
+      - name: ⬇️  Checkout repository
         uses: actions/checkout@v4.1.1
 
       - name: 🔑 Log in to the Container registry

--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: 📲 Install dependencies
-        run: npm clean-install
+        run: |
+          npm install
+          npm clean-install
       - name: 📝 Test
         run: npm run test-headless
     

--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -28,13 +28,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: 📲 Install dependencies
-        run: |
-          npm install
-          npm clean-install
+        run: npm clean-install
       - name: 📝 Test
-        run: |
-          npm run build
-          npm run test
+        run: npm run test-headless
     
 
   build-and-push-image:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build:app && npm run build:widgets",
     "test": "ng test --source-map=false",
     "test-intellij": "ng test 2>&1 | perl -e '$|++; while (<>) { s/((ERROR|WARNING) in\\s*)(.*)/$1\\n$3/g; print $_; }'",
-    "test-headless": "ng test --watch=false --browsers=ChromeHeadless",
+    "test-headless": "ng test --source-map=false --watch=false --browsers=ChromeHeadless",
     "lint": "tslint src/**/*.ts",
     "e2e": "ng e2e",
     "postversion": "git push && git push --tags",

--- a/src/app/profile/components/app-integrations-list/app-integrations-list.component.spec.ts
+++ b/src/app/profile/components/app-integrations-list/app-integrations-list.component.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Injectable, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { By } from '@angular/platform-browser';
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
-// import 'rxjs/add/observable/throw';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 import {Component, Directive} from '@angular/core';
 import {AppIntegrationListComponent} from './app-integrations-list.component';
@@ -34,6 +32,7 @@ describe('AppIntegrationListComponent', () => {
 				RouterTestingModule,
 				CommonModule,
 				BadgrCommonModule,
+                TranslateTestingModule.withTranslations('de', {}),
 				...COMMON_IMPORTS,
 			],
 			providers: [

--- a/src/app/recipient/components/add-badge-dialog/add-badge-dialog.component.spec.ts
+++ b/src/app/recipient/components/add-badge-dialog/add-badge-dialog.component.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Injectable, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { By } from '@angular/platform-browser';
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
-// import 'rxjs/add/observable/throw';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 import {Component, Directive, ElementRef, Renderer2} from '@angular/core';
 import {AddBadgeDialogComponent} from './add-badge-dialog.component';
@@ -30,6 +28,7 @@ describe('AddBadgeDialogComponent', () => {
 				RouterTestingModule,
 				CommonModule,
 				BadgrCommonModule,
+                TranslateTestingModule.withTranslations('de', {}),
 				...COMMON_IMPORTS,
 			],
 			providers: [

--- a/src/app/recipient/components/recipient-badge-collection-create/recipient-badge-collection-create.component.spec.ts
+++ b/src/app/recipient/components/recipient-badge-collection-create/recipient-badge-collection-create.component.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Injectable, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { By } from '@angular/platform-browser';
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
-// import 'rxjs/add/observable/throw';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 import {Component, Directive} from '@angular/core';
 import {RecipientBadgeCollectionCreateComponent} from './recipient-badge-collection-create.component';
@@ -34,6 +32,7 @@ describe('RecipientBadgeCollectionCreateComponent', () => {
 				RouterTestingModule,
 				CommonModule,
 				BadgrCommonModule,
+                TranslateTestingModule.withTranslations('de', {}),
 				...COMMON_IMPORTS,
 			],
 			providers: [

--- a/src/app/recipient/components/recipient-badge-collection-list/recipient-badge-collection-list.component.spec.ts
+++ b/src/app/recipient/components/recipient-badge-collection-list/recipient-badge-collection-list.component.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Injectable, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { By } from '@angular/platform-browser';
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
-// import 'rxjs/add/observable/throw';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 import {Component, Directive} from '@angular/core';
 import {RecipientBadgeCollectionListComponent} from './recipient-badge-collection-list.component';
@@ -35,6 +33,7 @@ describe('RecipientBadgeCollectionListComponent', () => {
 				RouterTestingModule,
 				CommonModule,
 				BadgrCommonModule,
+                TranslateTestingModule.withTranslations('de', {}),
 				...COMMON_IMPORTS,
 			],
 			providers: [

--- a/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.spec.ts
+++ b/src/app/recipient/components/recipient-earned-badge-list/recipient-earned-badge-list.component.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Injectable, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { By } from '@angular/platform-browser';
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/of';
-// import 'rxjs/add/observable/throw';
+import { TranslateTestingModule } from 'ngx-translate-testing';
 
 import {Component, Directive} from '@angular/core';
 import {RecipientEarnedBadgeListComponent} from './recipient-earned-badge-list.component';
@@ -34,6 +32,7 @@ describe('RecipientEarnedBadgeListComponent', () => {
 				RouterTestingModule,
 				CommonModule,
 				BadgrCommonModule,
+                TranslateTestingModule.withTranslations('de', {}),
 				...COMMON_IMPORTS,
 			],
 			providers: [


### PR DESCRIPTION
Added run to workflow file to execute the tests. The tests are run headless, thus `npm run test-headless` is called (instead of `npm test` or similar).
Also note that I already merged the branch `ui-fix-translation-test-issues` into this branch, since the newly added action fails otherwise (see [this](https://github.com/mint-o-badges/badgr-ui/pull/10) PR).