### PR TITLE
UI create curtain

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <ng-template sourceListener></ng-template>
-<header class="o-container">
+<header class="o-container" *ngIf="!curtain">
 	<nav class="navbar l-containerxaxis l-stickyfooter-x-nav" [class.navbar-light]="!theme.useColorNavbar">
 		<a
 			[class.logo-is-loading]="isRequestPending"
@@ -283,9 +283,35 @@
 		</div>
 	</nav>
 </header>
-<div class="loader l-stickyfooter-x-loader"></div>
+<div *ngIf="!curtain" class="loader l-stickyfooter-x-loader"></div>
 
-<main
+<!-- Display a "curtain" instead of the normal page, if `curtain` is set to true-->
+<div *ngIf="curtain" class="l-stickyfooter-x-main o-container">
+    <div class="l-flex l-flex-justifycenter l-flex-aligncenter flex-wrap u-margin-bottom8x">
+        <div class="l-flex flex-1 l-flex-aligncenter l-flex-justifycenter">
+            <div class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
+                <h1 class="u-text-h1 u-text-dark2">
+                    Open Educational Badges
+                </h1>
+            </div>
+        </div>
+    </div>
+    <div class="panel">
+        <div class="center">
+            <h1 class="u-text-h2">Coming soon - 1. April 2024</h1>
+            <!--TODO: This is very hacky-->
+            <h1 class="u-text-h1 u-text-dark2">&nbsp;</h1>
+        </div>
+        <div class="video-container">
+            <video width="80%" controls>
+                <source src="assets/videos/badges-curtain.mp4" type="video/mp4">
+            </video>
+        </div>
+    </div>
+</div>
+
+<!-- Display a "curtain" instead of the normal page, if `curtain` is set to true-->
+<main *ngIf="!curtain"
 	class="l-stickyfooter-x-main o-container"
 	[attr.inert]="mobileNavOpen ? '' : null"
 	[class.l-inertcontainer]="mobileNavOpen"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,22 @@
+.flex-1 {
+	flex: 1;
+}
+
+.flex-wrap {
+	flex-wrap: wrap;
+}
+.video-container {
+	height: 500px;
+	width: 100%;
+	padding-bottom: 5rem;
+}
+
+.panel {
+	background-color: #00729c;
+	padding: 5rem;
+	text-align: center;
+	position: relative;
+	max-width: 100%;
+	color: white;
+	border-radius: 1rem;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,8 +45,17 @@ import { TranslateService } from '@ngx-translate/core';
 		'[class.l-stickyfooter-chromeless]': '! showAppChrome',
 	},
 	templateUrl: './app.component.html',
+    styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit, AfterViewInit {
+    /**
+     * Enables or disables the "curtain" feature, hiding the normal page.
+     */
+    curtainEnabled = true;
+    get curtain() {
+        return this.curtainEnabled && !this.router.url.includes('impressum');
+    }
+
 	title = 'Badgr Angular';
 	loggedIn = false;
 	mobileNavOpen = false;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,6 +53,20 @@ export class AppComponent implements OnInit, AfterViewInit {
      */
     curtainEnabled = true;
     get curtain() {
+        let re = /\?curtainEnabled=(\w*)/i;
+        let match = this.router.url.match(re);
+        if (match && match.length == 2) {
+            let param: string = match[1];
+            if (param == 'false' || param == 'true' ||
+                param == 'yes' || param == 'no')
+                localStorage.setItem("curtainEnabled",
+                                     param == 'true' || param == 'yes'
+                                         ? 'true' : 'false');
+        }
+
+        let local = localStorage.getItem("curtainEnabled");
+        if (local == 'false' || local == 'true')
+            this.curtainEnabled = localStorage.getItem("curtainEnabled") == 'true';
         return this.curtainEnabled && !this.router.url.includes('impressum');
     }
 

--- a/src/app/public/components/start/start.component.html
+++ b/src/app/public/components/start/start.component.html
@@ -1,28 +1,4 @@
-<div *ngIf="curtain" class="curtain">
-    <div class="l-flex l-flex-justifycenter l-flex-aligncenter flex-wrap u-margin-bottom8x">
-        <div class="l-flex flex-1 l-flex-aligncenter l-flex-justifycenter">
-            <div class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
-                <h1 class="u-text-h1 u-text-dark2">
-                    Open Educational Badges
-                </h1>
-            </div>
-        </div>
-    </div>
-    <div class="panel">
-        <div class="center">
-            <h1 class="u-text-h2">Coming soon - 1. April 2024</h1>
-            <!--TODO: This is very hacky-->
-			<h1 class="u-text-h1 u-text-dark2">&nbsp;</h1>
-        </div>
-        <div class="video-container">
-            <video width="60%" controls>
-                <source src="assets/videos/badges-curtain.mp4" type="video/mp4">
-            </video>
-        </div>
-    </div>
-</div>
-
-<div *ngIf="!curtain" class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
+<div class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
 	<form-message></form-message>
 	<div class="l-flex l-flex-justifycenter l-flex-aligncenter flex-wrap u-margin-bottom8x">
 		<div class="l-flex flex-1 l-flex-aligncenter l-flex-justifycenter">

--- a/src/app/public/components/start/start.component.html
+++ b/src/app/public/components/start/start.component.html
@@ -1,6 +1,29 @@
-<div class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
-	<form-message></form-message>
+<div *ngIf="curtain" class="curtain">
+    <div class="l-flex l-flex-justifycenter l-flex-aligncenter flex-wrap u-margin-bottom8x">
+        <div class="l-flex flex-1 l-flex-aligncenter l-flex-justifycenter">
+            <div class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
+                <h1 class="u-text-h1 u-text-dark2">
+                    Open Educational Badges
+                </h1>
+            </div>
+        </div>
+    </div>
+    <div class="panel">
+        <div class="center">
+            <h1 class="u-text-h2">Coming soon - 1. April 2024</h1>
+            <!--TODO: This is very hacky-->
+			<h1 class="u-text-h1 u-text-dark2">&nbsp;</h1>
+        </div>
+        <div class="video-container">
+            <video width="60%" controls>
+                <source src="assets/videos/badges-curtain.mp4" type="video/mp4">
+            </video>
+        </div>
+    </div>
+</div>
 
+<div *ngIf="!curtain" class="l-containerxaxis l-containeryaxis l-flex l-flex-justifycenter l-flex-column">
+	<form-message></form-message>
 	<div class="l-flex l-flex-justifycenter l-flex-aligncenter flex-wrap u-margin-bottom8x">
 		<div class="l-flex flex-1 l-flex-aligncenter l-flex-justifycenter">
 			<img class="logo" src="assets/logos/Badges_Entwurf-15.svg" alt="My Badges" />

--- a/src/app/public/components/start/start.component.ts
+++ b/src/app/public/components/start/start.component.ts
@@ -7,8 +7,6 @@ import { Component, OnInit } from '@angular/core';
 })
 export class StartComponent implements OnInit {
 
-    curtain = true;
-
     constructor() { }
 
     ngOnInit() {

--- a/src/app/public/components/start/start.component.ts
+++ b/src/app/public/components/start/start.component.ts
@@ -1,15 +1,16 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-start',
-  templateUrl: './start.component.html',
-  styleUrls: ['./start.component.scss']
+    selector: 'app-start',
+    templateUrl: './start.component.html',
+    styleUrls: ['./start.component.scss']
 })
 export class StartComponent implements OnInit {
 
-  constructor() { }
+    curtain = true;
 
-  ngOnInit() {
-  }
+    constructor() { }
 
+    ngOnInit() {
+    }
 }

--- a/src/breakdown/static/css/re-style.css
+++ b/src/breakdown/static/css/re-style.css
@@ -60,3 +60,19 @@
 .autocomplete-container .suggestions-container {
     z-index: -1
 }
+
+/*
+ * The curtain should draw in front of everything and hide it.
+ */
+.curtain {
+    position:fixed;
+    padding:0;
+    margin:0;
+
+    top:0;
+    left:0;
+
+    width: 100%;
+    height: 100%;
+    background:rgb(255,255,255);
+}

--- a/src/breakdown/static/css/re-style.css
+++ b/src/breakdown/static/css/re-style.css
@@ -60,19 +60,3 @@
 .autocomplete-container .suggestions-container {
     z-index: -1
 }
-
-/*
- * The curtain should draw in front of everything and hide it.
- */
-.curtain {
-    position:fixed;
-    padding:0;
-    margin:0;
-
-    top:0;
-    left:0;
-
-    width: 100%;
-    height: 100%;
-    background:rgb(255,255,255);
-}


### PR DESCRIPTION
Add a curtain that is enabled by default and covers the whole page, except for the imprint. If the imprint is displayed, there's no curtain, but on all other pages.

The curtain can be disabled by the query parameter `curtainEnabled` (e.g. http://localhost:4200/public/start?curtainEnabled=false). The enabled / disabled state is stored in the local storage, so that the query parameter doesn't have to be persisted.