### PR TITLE
Fix error message on signup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -256,7 +256,8 @@ export class AppComponent implements OnInit, AfterViewInit {
 		this.sessionService.loggedin$.subscribe((loggedIn) =>
 			setTimeout(() => {
 				this.loggedIn = loggedIn;
-				this.refreshProfile();
+                if (loggedIn)
+                    this.refreshProfile();
 			}),
 		);
 		this.shouldShowIssuersTab();

--- a/src/app/signup/components/signup-success/signup-success.component.ts
+++ b/src/app/signup/components/signup-success/signup-success.component.ts
@@ -24,7 +24,11 @@ constructor(
 	email: string;
 
 	ngOnInit() {
-		this.sessionService.logout();
+        // Ensure the user isn't logged in here, by removing relevant
+        // tokens. Don't trigger a change to the loggedInSubject
+        // observable though, since the user typically shouldn't
+        // be logged in at this point anyway.
+		this.sessionService.logout(false);
 		this.email = decodeURIComponent(atob(this.routeParams.snapshot.params[ 'email' ]));
 	}
 


### PR DESCRIPTION
The error message appeared because `refreshProfile` was called when the loggedIn observable was triggered, which was caused because logout was called even though the user was already logged out on registration. Now logout is still called, but with a parameter to ensure that the observable isn't triggered. Also, `refreshProfile` is only called if the user is actually loggedIn when a change is detected.