### PR TITLE
show based on link only if the badge is based on another badge

### DIFF
--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.html
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.html
@@ -71,7 +71,7 @@
 								</dd>
 							</div>
 						</div>
-						<div *ngIf="badgeClass.extension['extensions:BasedOnExtension']" class="l-flex l-flex-2x u-padding-top2x border border-top border-light3">
+						<div *ngIf="badgeClass.extension['extensions:BasedOnExtension'].BasedOn.slug" class="l-flex l-flex-2x u-padding-top2x border border-top border-light3">
 							<div>
 								<dt class="u-text-small-bold u-text-dark2"><a 
 									class="u-break-word" 


### PR DESCRIPTION
Currently the "Basierend auf ->"-LInk is always displayed. WIth this PR it will only be displayed if the badge is based on another badge.