### PR TITLE
show error message if trying to add user that does not exist

### DIFF
--- a/src/app/issuer/components/issuer-staff-create-dialog/issuer-staff-create-dialog.component.ts
+++ b/src/app/issuer/components/issuer-staff-create-dialog/issuer-staff-create-dialog.component.ts
@@ -77,8 +77,9 @@ export class IssuerStaffCreateDialogComponent extends BaseDialog {
 			},
 			error => {
 				const err = BadgrApiFailure.from(error)
+				console.log(err);
 				this.error =
-					BadgrApiFailure.messageIfThrottableError(JSON.parse(err.overallMessage)) ||
+					BadgrApiFailure.messageIfThrottableError(err.overallMessage) ||
 					`Failed to add member: ${err.firstMessage}`;
 			}
 		);


### PR DESCRIPTION
The user interface now shows the error message when you add a user that does not exist.

![image](https://github.com/mint-o-badges/badgr-ui/assets/2675557/597ed903-c6ff-4fc4-a790-ab762434c90f)
