### PR TITLE
Tagged version is pointing to staging

### DIFF
--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -71,6 +71,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: 🏗️ Build and push Docker Staging image
+        # Only build main images for Staging
+        if: ${{ contains(steps.meta.output.tags, 'main') }}
         uses: docker/build-push-action@v5.0.0
         with:
           context: .


### PR DESCRIPTION
Only build main images for Staging. I can't test if this actually works until it's merged. This should fix the issue, because otherwise it always tries to build an extra image and for tagged versions, there are two tags (the version tag and `latest`), meaning that only the second tag gets the `-Staging` postfix. If only images for `main` are built, as long as images with `main` don't have two tags, this should solve the issue.