### PR TITLE
update company name in imprint #217

### DIFF
--- a/src/app/public/components/impressum/impressum.component.html
+++ b/src/app/public/components/impressum/impressum.component.html
@@ -56,15 +56,9 @@
 			Weitere Verbundpartner:innen:
 		</h3>
 		<p style="font-size: 1.1rem; color: black; line-height: 1.55; margin: 1.3em 0 1.3em">
-			<span style="font-weight: bold"> matrix </span>
+			<span style="font-weight: bold"> matrix gGmbH </span>
 			<br />
-			<span style="font-weight: bold">
-				Gesellschaft für Beratung in Wirtschaft, Politik und Verwaltung mbH & Co. KG
-			</span>
-			<br />
-			Rittergut Haus Morp
-			<br />
-			Düsseldorfer Straße 16
+			Rittergut Haus Morp | Düsseldorfer Straße 16
 			<br />
 			40699 Erkrath bei Düsseldorf
 			<br /><br />


### PR DESCRIPTION
matrix [...] GmbH & Co. KG is not correct. It needs to be

matrix gGmbH
Rittergut Haus Morp | Düsseldorfer Straße 16 
40699 Erkrath bei Düsseldorf