### PR TITLE
PDF export: Don't fail on missing issuer image

### DIFF
--- a/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
+++ b/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
@@ -304,8 +304,8 @@ export class ExportPdfDialog extends BaseDialog {
 		const badge_image = await this.convertImageToDataURL(badgeClass.image);
 		const badge_image_aspectRatio = await this.getAspectRatio(badge_image);
 
-		const issuer_image = await this.convertImageToDataURL(badgeClass.issuer.image);
-		const issuer_image_aspectRatio = await this.getAspectRatio(issuer_image);
+		const issuer_image = badgeClass.issuer.image ? await this.convertImageToDataURL(badgeClass.issuer.image) : null;
+		const issuer_image_aspectRatio = issuer_image ? await this.getAspectRatio(issuer_image) : null;
 
 		const svgContentClock = `
 		<svg xmlns="http://www.w3.org/2000/svg" height="14" width="12.25" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="#492e98" d="M176 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h16V98.4C92.3 113.8 16 200 16 304c0 114.9 93.1 208 208 208s208-93.1 208-208c0-41.8-12.3-80.7-33.5-113.2l24.1-24.1c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L355.7 143c-28.1-23-62.2-38.8-99.7-44.6V64h16c17.7 0 32-14.3 32-32s-14.3-32-32-32H224 176zm72 192V320c0 13.3-10.7 24-24 24s-24-10.7-24-24V192c0-13.3 10.7-24 24-24s24 10.7 24 24z"/></svg>`;
@@ -463,9 +463,11 @@ export class ExportPdfDialog extends BaseDialog {
 						addIssuedBy(this.doc);
 
 						// issuer logo
-						yPos += 5;
-						const issuer_image_height = 30 * issuer_image_aspectRatio;
-						this.doc.addImage(issuer_image, 'PNG', pageWidth / 2 - 15, yPos - 2, 30, issuer_image_height);
+                        if (issuer_image) {
+                            yPos += 5;
+                            const issuer_image_height = 30 * issuer_image_aspectRatio;
+                            this.doc.addImage(issuer_image, 'PNG', pageWidth / 2 - 15, yPos - 2, 30, issuer_image_height);
+                        }
 
 						//footer
 						const pageCount = (this.doc as any).internal.getNumberOfPages(); //was doc.internal.getNumberOfPages();


### PR DESCRIPTION
If the issuer that created a badge has no image, the PDF export fails with the following error:
```js
ERROR Error: Failed to load image
    at img.onerror [as __zone_symbol__ON_PROPERTYerror] (export-pdf-dialog.component.ts:147:12)
    at Image.wrapFn (zone.umd.js:810:43)
    at _ZoneDelegate.invokeTask (zone.umd.js:445:35)
    at core.mjs:14506:55
    at AsyncStackTaggingZoneSpec.onInvokeTask (core.mjs:14506:36)
    at _ZoneDelegate.invokeTask (zone.umd.js:444:64)
    at Object.onInvokeTask (core.mjs:14819:33)
    at _ZoneDelegate.invokeTask (zone.umd.js:444:64)
    at Zone.runTask (zone.umd.js:210:51)
    at ZoneTask.invokeTask [as invoke] (zone.umd.js:527:38)
```