### PR TITLE
feat(tracking):add umami tracking for all environments

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -68,6 +68,10 @@
 							"extractLicenses": true,
 							"vendorChunk": false,
 							"buildOptimizer": true,
+							"index": {
+								"input": "src/index.production.html",
+								"output": "index.html"
+							},
 							"fileReplacements": [
 								{
 									"replace": "src/environments/environment.ts",
@@ -89,6 +93,10 @@
 							"extractLicenses": true,
 							"vendorChunk": false,
 							"buildOptimizer": true,
+							"index": {
+								"input": "src/index.staging.html",
+								"output": "index.html"
+							},
 							"fileReplacements": [
 								{
 									"replace": "src/environments/environment.ts",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,10 +50,10 @@ export class AppComponent implements OnInit, AfterViewInit {
 	 * Enables or disables the "curtain" feature, hiding the normal page.
 	 */
 	curtainEnabled = true;
-    /**
-     * Permanently disables the curtain, making it impossible to show it even with the query parameter
-     */
-    curtainPermanentlyDisabled = true;
+	/**
+	 * Permanently disables the curtain, making it impossible to show it even with the query parameter
+	 */
+	curtainPermanentlyDisabled = true;
 	get curtain() {
 		let re = /\?curtainEnabled=(\w*)/i;
 		let match = this.router.url.match(re);
@@ -65,8 +65,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
 		let local = localStorage.getItem('curtainEnabled');
 		if (local == 'false' || local == 'true') this.curtainEnabled = localStorage.getItem('curtainEnabled') == 'true';
-		return this.curtainEnabled && !this.router.url.includes('impressum') &&
-            !this.curtainPermanentlyDisabled;
+		return this.curtainEnabled && !this.router.url.includes('impressum') && !this.curtainPermanentlyDisabled;
 	}
 
 	title = 'Badgr Angular';
@@ -169,6 +168,10 @@ export class AppComponent implements OnInit, AfterViewInit {
 				this.selectedLng = lng;
 			}
 		});
+
+		// @ts-ignore
+		// Start umami tracking
+		umami.track();
 
 		messageService.useRouter(router);
 

--- a/src/app/public/components/impressum/impressum.component.html
+++ b/src/app/public/components/impressum/impressum.component.html
@@ -326,6 +326,20 @@
 			</span>
 		</p>
 
+		<h3 style="font-weight: bold; margin-top: 1.3em" class="u-text-h3-semibold u-text-dark2">
+			4.4 Erhebung von Nutzungsstatistiken
+		</h3>
+		<p style="font-size: 1.1rem; color: black; line-height: 1.55; margin: 0.5em 0 1.3em">
+			<span style="display: block; margin-bottom: 0.9em">
+				<ul style="list-style: disc; list-style-position: inside; padding-left: 1.2em">
+					<li>Diese Website verwendet ein datenschutzfreundliches System für grundlegende Analysen, um zu verstehen, wie diese Website genutzt wird.</li>
+					<li>Diese Website sammelt nur die grundlegenden Informationen, die von dem Browser oder dem Gerät, das Sie für den Zugriff auf diese und andere Websites verwenden, dargestellt werden.</li>
+					<li>Keine der gesammelten Informationen kann zur persönlichen Identifizierung einer Person oder eines Geräts verwendet werden, das auf diese Website zugreift.</li>
+					<li>Die gesammelten Informationen werden nicht an Dritte weitergegeben, egal aus welchem Grund.</li>
+				</ul>
+			</span>
+		</p>
+
 		<!-- Dauer der Verarbeitung - 5 -->
 		<h2 class="u-text-h2-bold u-margin-bottom2x u-text-dark2 u-margin-top4x">5. Dauer der Verarbeitung</h2>
 		<p style="font-size: 1.1rem; color: black; line-height: 1.55; margin: 0.5em 0 1.3em">

--- a/src/index.production.html
+++ b/src/index.production.html
@@ -88,7 +88,7 @@
 		<script src="/assets/ace-builds/ace.js"></script>
 
 		<!-- Include umami tracking -->
-		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="63bed671-0424-436a-bcbc-9503b70482d9"></script>
+		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="a46e7b01-b422-4ae7-8f9c-692ec65e78aa"></script>
 	</head>
 	<body>
 		<app-root class="l-stickyfooter u-background-light2"></app-root>

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -88,7 +88,7 @@
 		<script src="/assets/ace-builds/ace.js"></script>
 
 		<!-- Include umami tracking -->
-		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="63bed671-0424-436a-bcbc-9503b70482d9"></script>
+		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="0ed35f0f-70c4-4e87-a3de-7a962af7ee79"></script>
 	</head>
 	<body>
 		<app-root class="l-stickyfooter u-background-light2"></app-root>


### PR DESCRIPTION
We no have a self-hosted [umami](https://umami.is) instance at https://umami.opensenselab.org

This PR adds `umami` to all build stages (`development`, `staging` and `production`) and closes #271. I have followed @umut0 suggestion to copy the `index.html` for all stages. Now there are three `index.html` files. They are all the same just differ in the `website-id` for `umami`. 

- `index.html`-> `development` (localhost:4200)
- `index.staging.html` -> `staging`
- `index.production.html` -> `production`

The index files used for the different stages are configure in the `angular.json` configuration.

> ⚠️ Remember to adjust all three index files if you change anything

PS: committing the `websiteIds` should be fine because they are bound to a domain.