### PR TITLE
release from release branch

### DIFF
--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -2,7 +2,7 @@ name: 🏗️ Build and publish to Github Container Registry
 
 on:
   push:
-    branches: [main]
+    branches: [main,release]
     tags: ["v*.*.*"]
   pull_request:
     branches:


### PR DESCRIPTION
### Also build release branch

In order to automatically deploy builds from the release branch, we need builds from the release branch.

This should be all that's necessary to change in the codebase; the rest I need to adjust directly on the production server.