### PR TITLE
Also display not verified text in wide view

### DIFF
--- a/src/app/issuer/components/issuer-detail/issuer-detail.component.html
+++ b/src/app/issuer/components/issuer-detail/issuer-detail.component.html
@@ -20,19 +20,24 @@
 					</p>
 				</div>
 			</div>
-			<div class="l-primarymore tw-w-auto tw-hidden md:tw-grid !tw-content-center">
-				<button
-					class="button"
-					[routerLink]="['./badges/create']"
-					[disabled]="!issuer.apiModel.verified"
-				>
-					{{ 'Issuer.createBadge' | translate }}
-				</button>
-				<button class="buttonicon buttonicon-secondary" [bgPopupMenuTrigger]="issuerActionsMenu">
-					<svg icon="icon_more"></svg>
-					<span class="visuallyhidden">{{ 'General.more' | translate }}</span>
-				</button>
-			</div>
+            <div class="tw-w-auto tw-hidden md:tw-grid !tw-content-center">
+                <p *ngIf="!issuer.apiModel.verified" class="u-margin-top1x u-width-paragraph">
+                {{ 'Issuer.nichtVerified' | translate }}
+                </p>
+                <div class="l-primarymore">
+                    <button
+                            class="button"
+                            [routerLink]="['./badges/create']"
+                            [disabled]="!issuer.apiModel.verified"
+                            >
+                            {{ 'Issuer.createBadge' | translate }}
+                    </button>
+                        <button class="buttonicon buttonicon-secondary" [bgPopupMenuTrigger]="issuerActionsMenu">
+                            <svg icon="icon_more"></svg>
+                            <span class="visuallyhidden">{{ 'General.more' | translate }}</span>
+                        </button>
+                </div>
+            </div>
 		</div>
 		<div>
 			<p class="tw-text-oebblack tw-py-4">{{issuer.description}}</p>


### PR DESCRIPTION
Before the text indicating a non verified issuer was only shown in the compact (mobile?) view. Now it's also displayed in the wider view.