### PR TITLE
feat: disable OIDC login for prod

### DIFF
--- a/src/app/auth/components/login/login.component.html
+++ b/src/app/auth/components/login/login.component.html
@@ -60,7 +60,8 @@
                             variant="blackborder"
                             size="md"
                             [text]='"Login.loginBildungsraum" | translate'
-                            (click)=bildungsraumLogin()>
+                            (click)=bildungsraumLogin()
+                            [disabled]='isOidcDisabled()'>
 							
 						</oeb-button>
 					</div>

--- a/src/app/auth/components/login/login.component.ts
+++ b/src/app/auth/components/login/login.component.ts
@@ -157,6 +157,8 @@ export class LoginComponent extends BaseRoutableComponent implements OnInit, Aft
     }
 
     bildungsraumLogin() {
+        if (this.isOidcDisabled())
+            return;
         const endpoint = this.sessionService.baseUrl + '/oidc/authenticate';
         window.location.href = endpoint;
     }
@@ -253,4 +255,9 @@ export class LoginComponent extends BaseRoutableComponent implements OnInit, Aft
 		this.verifiedName = this.queryParams.queryStringValue('name');
 		this.verifiedEmail = this.queryParams.queryStringValue('email');
 	}
+
+    isOidcDisabled(): boolean {
+        const prodUrl = "https://openbadges.education";
+        return location.origin === prodUrl;
+    }
 }


### PR DESCRIPTION
The button is disabled and the function returns if the urls matche sthe production url.

Note that we can't be 100% sure that this works until we try it on prod. I have tried it with the localhost url instead though and I'm fairly certain that it *should* work.