### PR TITLE
feat: remove linked js library

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -93,8 +93,9 @@
 		<!-- Include umami tracking -->
 		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="63bed671-0424-436a-bcbc-9503b70482d9"></script>
 
+		<!-- It's commented out till we figure out if this is the best option to resvole 'marked is not defined' console error -->
 		<!-- To resolve 'marked is not defined' when relaoding create-badge page -->
-		<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+		<!-- <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> -->
 	</head>
 	<body>
 		<app-root class="oeb-stickyfooter u-background-light2"></app-root>

--- a/src/index.production.html
+++ b/src/index.production.html
@@ -90,8 +90,9 @@
 		<!-- Include umami tracking -->
 		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="a46e7b01-b422-4ae7-8f9c-692ec65e78aa"></script>
 
+		<!-- It's commented out till we figure out if this is the best option to resvole 'marked is not defined' console error -->
 		<!-- To resolve 'marked is not defined' when relaoding create-badge page -->
-		<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+		<!-- <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> -->
 	</head>
 	<body>
 		<app-root class="oeb-stickyfooter u-background-light2"></app-root>

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -90,8 +90,9 @@
 		<!-- Include umami tracking -->
 		<script defer src="https://umami.opensenselab.org/script.js" data-website-id="0ed35f0f-70c4-4e87-a3de-7a962af7ee79"></script>
 
+		<!-- It's commented out till we figure out if this is the best option to resvole 'marked is not defined' console error -->
 		<!-- To resolve 'marked is not defined' when relaoding create-badge page -->
-		<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+		<!-- <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script> -->
 	</head>
 	<body>
 		<app-root class="oeb-stickyfooter u-background-light2"></app-root>


### PR DESCRIPTION
The removed library was linked to resolve 'marked is not defined' error  when relaoding create-badge page. It's now removed as it raises some concerns about privacy policy.