### PR TITLE
fix: calculate studyLoad correctly

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -877,7 +877,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 					'extensions:StudyLoadExtension': {
 						'@context': studyLoadExtensionContextUrl,
 						type: ['Extension', 'extensions:StudyLoadExtension'],
-						StudyLoad: Number(formState.badge_hours * 60 + formState.badge_minutes),
+						StudyLoad: Number(formState.badge_hours * 60) + Number(formState.badge_minutes),
 					},
 					'extensions:CategoryExtension': {
 						'@context': categoryExtensionContextUrl,
@@ -928,7 +928,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 						'extensions:StudyLoadExtension': {
 							'@context': studyLoadExtensionContextUrl,
 							type: ['Extension', 'extensions:StudyLoadExtension'],
-							StudyLoad: Number(formState.badge_hours * 60 + formState.badge_minutes),
+							StudyLoad: Number(formState.badge_hours * 60) + Number(formState.badge_minutes),
 						},
 						'extensions:CategoryExtension': {
 							'@context': categoryExtensionContextUrl,
@@ -1002,7 +1002,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 				name: String(competency.name),
 				description: String(competency.description),
 				escoID: String(competency.escoID),
-				studyLoad: Number(competency.hours * 60 + competency.minutes),
+				studyLoad: Number(competency.hours * 60) + Number(competency.minutes),
 				hours: Number(competency.hours),
 				minutes: Number(competency.minutes),
 				category: String(competency.category),


### PR DESCRIPTION
The studyload is not calculated correctly with the new hours and minutes field, e.g. when adding 1 hour and 30 minutes it results to 100 hours and 30 minutes