### PR TITLE
feat: set manager as root provided, reduce server requests

### DIFF
--- a/src/app/common/badgr-common.module.ts
+++ b/src/app/common/badgr-common.module.ts
@@ -196,7 +196,6 @@ export const COMMON_MODULE_COMPONENTS = [
 const SERVICES = [
 	CommonDialogsService,
 	CommonEntityManager,
-	IssuerManager,
 	IssuerApiService,
 	MessageService,
 	SettingsService,
@@ -208,9 +207,7 @@ const SERVICES = [
 	EventsService,
 	SessionService,
 	QueryParametersService,
-	UserProfileManager,
 	UserProfileApiService,
-	OAuthManager,
 	OAuthApiService,
 	EmbedService,
 	InitialLoadingIndicatorService,
@@ -270,7 +267,7 @@ export const COMMON_IMPORTS = [
 
 @NgModule({
 	imports: [...COMMON_IMPORTS, FormsModule, LMarkdownEditorModule, TranslateModule, SharedIconsModule, CdkStepperModule],
-	providers: [BadgeClassManager, BadgeClassApiService,  ...serverErrorInterceptorFactory()],
+	providers: [BadgeClassApiService,  ...serverErrorInterceptorFactory()],
 	declarations: [...DIRECTIVES, ...COMMON_MODULE_COMPONENTS, ...PIPES, ForwardRouteComponent, BadgeLegendComponent, CountUpDirective],
 	exports: [...DIRECTIVES, ...COMMON_MODULE_COMPONENTS, ...PIPES, BadgeLegendComponent, SharedIconsModule],
 })

--- a/src/app/common/guards/auth.guard.ts
+++ b/src/app/common/guards/auth.guard.ts
@@ -3,6 +3,7 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/ro
 import { SessionService } from '../services/session.service';
 import { OAuthManager } from '../services/oauth-manager.service';
 import { UserProfileApiService } from '../services/user-profile-api.service';
+import { UserProfileManager } from '../services/user-profile-manager.service';
 
 @Injectable()
 export class AuthGuard {
@@ -10,7 +11,7 @@ export class AuthGuard {
 		private sessionService: SessionService,
 		private router: Router,
 		private oAuthManager: OAuthManager,
-		private userProfileApiService: UserProfileApiService,	
+		private userProfileManager: UserProfileManager,
 	) {}
 
 	canActivate(
@@ -30,10 +31,10 @@ export class AuthGuard {
 		} else if (this.oAuthManager.isAuthorizationInProgress) {
 			this.router.navigate(['/auth/oauth2/authorize']);
 			return false;
-		} 		
+		}
 		else {
-			this.userProfileApiService.getProfile().then(profile => {
-				if (profile.agreed_terms_version !== profile.latest_terms_version) {
+			this.userProfileManager.userProfilePromise.then(profile => {
+				if (profile.agreedTermsVersion !== profile.latestTermsVersion) {
 					this.router.navigate(['/auth/new-terms']);
 					return false;
 				}

--- a/src/app/common/services/oauth-manager.service.ts
+++ b/src/app/common/services/oauth-manager.service.ts
@@ -15,7 +15,9 @@ import { CommonDialogsService } from './common-dialogs.service';
 
 const OAUTH_STATE_STORAGE_NAME = 'oauthState';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class OAuthManager {
 	readonly authorizedApps = new StandaloneEntitySet<OAuth2AppAuthorization, ApiOAuth2AppAuthorization>(
 		() => new OAuth2AppAuthorization(this.commonEntityManager),

--- a/src/app/common/services/user-profile-manager.service.ts
+++ b/src/app/common/services/user-profile-manager.service.ts
@@ -4,12 +4,13 @@ import { StandaloneEntitySet } from '../model/managed-entity-set';
 import { UserProfile } from '../model/user-profile.model';
 import { ApiUserProfile } from '../model/user-profile-api.model';
 import { CommonEntityManager } from '../../entity-manager/services/common-entity-manager.service';
-import { resolve } from 'dns';
 
 /**
  * Manager for the singleton `UserProfile` instance that provides access to the current user's profile.
  */
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class UserProfileManager {
 	userProfileSet = new StandaloneEntitySet<UserProfile, ApiUserProfile>(
 		(apiModel) => new UserProfile(this.commonEntityManager),

--- a/src/app/issuer/issuer.module.ts
+++ b/src/app/issuer/issuer.module.ts
@@ -204,12 +204,8 @@ const routes = [
 	exports: [],
 	providers: [
 		BadgeClassApiService,
-		BadgeClassManager,
-		LearningPathManager,
 		BadgeInstanceApiService,
-		BadgeInstanceManager,
 		IssuerApiService,
-		IssuerManager,
 		QrCodeApiService,
 		BadgeRequestApiService,
 		CdkStepper

--- a/src/app/issuer/services/badgeclass-manager.service.ts
+++ b/src/app/issuer/services/badgeclass-manager.service.ts
@@ -21,7 +21,9 @@ import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { first, map } from 'rxjs/operators';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class BadgeClassManager extends BaseHttpApiService {
 	badgesList = new StandaloneEntitySet<BadgeClass, ApiBadgeClass>(
 		(apiModel) => new BadgeClass(this.commonEntityManager),

--- a/src/app/issuer/services/badgeinstance-manager.service.ts
+++ b/src/app/issuer/services/badgeinstance-manager.service.ts
@@ -4,7 +4,9 @@ import { BadgeInstanceApiService } from './badgeinstance-api.service';
 import { ApiBadgeInstanceForBatchCreation, ApiBadgeInstanceForCreation } from '../models/badgeinstance-api.model';
 import { CommonEntityManager } from '../../entity-manager/services/common-entity-manager.service';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class BadgeInstanceManager {
 	private instancesByBadgeClass: { [badgeClassSlug: string]: BadgeClassInstances } = {};
 

--- a/src/app/issuer/services/issuer-manager.service.ts
+++ b/src/app/issuer/services/issuer-manager.service.ts
@@ -7,7 +7,9 @@ import { StandaloneEntitySet } from '../../common/model/managed-entity-set';
 import { CommonEntityManager } from '../../entity-manager/services/common-entity-manager.service';
 import { first, map } from 'rxjs/operators';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class IssuerManager {
 	issuersList = new StandaloneEntitySet<Issuer, ApiIssuer>(
 		(apiModel) => new Issuer(this.commonEntityManager),

--- a/src/app/issuer/services/learningpath-manager.service.ts
+++ b/src/app/issuer/services/learningpath-manager.service.ts
@@ -12,7 +12,9 @@ import { LearningPath } from '../models/learningpath.model';
 import { ApiLearningPath } from '../../common/model/learningpath-api.model';
 import { LearningPathApiService } from '../../common/services/learningpath-api.service';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class LearningPathManager extends BaseHttpApiService {
 	learningPathList = new StandaloneEntitySet<LearningPath, ApiLearningPath>(
 		(apiModel) => new LearningPath(this.commonEntityManager),
@@ -52,7 +54,7 @@ export class LearningPathManager extends BaseHttpApiService {
 			.toPromise()
 			.then(
 				(lps) =>
-					lps.find((l) => l.slug === learningPathSlug) 
+					lps.find((l) => l.slug === learningPathSlug)
 			);
 	}
 }

--- a/src/app/issuer/services/qrcode-api.service.ts
+++ b/src/app/issuer/services/qrcode-api.service.ts
@@ -55,11 +55,11 @@ export class QrCodeApiService extends BaseHttpApiService {
 	}
 
 	downloadQrCode(blob: Blob, qrCodeName: string, badgeName: string): void {
-		const url = window.URL.createObjectURL(blob); 
+		const url = window.URL.createObjectURL(blob);
 		const link = document.createElement('a');
 		link.href = url;
 		link.download = `${qrCodeName}.pdf`;
 		link.click();
-		window.URL.revokeObjectURL(url); 
+		window.URL.revokeObjectURL(url);
 	  }
 }

--- a/src/app/profile/profile.module.ts
+++ b/src/app/profile/profile.module.ts
@@ -81,10 +81,10 @@ const routes: Routes = [
 	],
 	providers: [
 		// UserProfileService,
-		AppIntegrationApiService,
-		AppIntegrationManager,
+		// AppIntegrationApiService,
+		// AppIntegrationManager,
 		UserProfileApiService,
-		UserProfileManager,
+		// UserProfileManager,
 	],
 	exports: [],
 })

--- a/src/app/profile/services/app-integration-manager.service.ts
+++ b/src/app/profile/services/app-integration-manager.service.ts
@@ -5,7 +5,9 @@ import { AppIntegration } from '../models/app-integration.model';
 import { CommonEntityManager } from '../../entity-manager/services/common-entity-manager.service';
 import { AppIntegrationApiService } from './app-integration-api.service';
 
-@Injectable()
+@Injectable({
+	providedIn: 'root',
+})
 export class AppIntegrationManager {
 	appIntegrations = new StandaloneEntitySet<AppIntegration<ApiAppIntegration>, ApiAppIntegration>(
 		(apiEntity) => AppIntegration.integrationFor(this.commonManager, apiEntity),

--- a/src/app/public/components/about/newsletter/newsletter.component.ts
+++ b/src/app/public/components/about/newsletter/newsletter.component.ts
@@ -7,6 +7,7 @@ import { BaseRoutableComponent } from '../../../../common/pages/base-routable.co
 import { typedFormGroup } from '../../../../common/util/typed-forms';
 import { Validators } from '@angular/forms';
 import { UserProfileApiService } from '../../../../common/services/user-profile-api.service';
+import { UserProfileManager } from '../../../../common/services/user-profile-manager.service';
 import { SessionService } from '../../../../common/services/session.service';
 
 @Component({
@@ -22,8 +23,9 @@ export class NewsletterComponent extends BaseRoutableComponent implements OnInit
     .addControl('firstName', '', Validators.required)
     .addControl('lastName', '', Validators.required)
     constructor(
-        private translate: TranslateService, 
+        private translate: TranslateService,
         private userProfileApiService: UserProfileApiService,
+				private userProfileManager: UserProfileManager,
         private sessionService: SessionService,
         private renderer: Renderer2,
 		private elementRef: ElementRef,
@@ -34,18 +36,18 @@ export class NewsletterComponent extends BaseRoutableComponent implements OnInit
     }
 
     ngOnInit(): void {
-        const scriptElement = this.renderer.createElement('script');
- 		scriptElement.src = 'https://sibforms.com/forms/end-form/build/main.js';
+			const scriptElement = this.renderer.createElement('script');
+ 			scriptElement.src = 'https://sibforms.com/forms/end-form/build/main.js';
   		this.renderer.appendChild(this.elementRef.nativeElement, scriptElement);
-        this.userProfileApiService.getProfile().then(profile => {
-            this.userProfileApiService.fetchEmails().then(emails => {
-                this.newsletterForm.setValue({
-                    email: emails[0].email,
-                    firstName: profile.first_name,
-                    lastName: profile.last_name
-                });
-            })
-        })
+			this.userProfileManager.userProfilePromise.then(profile => {
+				profile.emails.loadedPromise.then(emails => {
+					this.newsletterForm.setValue({
+						email: emails.entities[0].email,
+						firstName: profile.firstName,
+						lastName: profile.lastName
+					});
+				})
+			})
     }
 
 


### PR DESCRIPTION
Configures the api manager classes to be "provided by the root application" turning them into singletons. This way injected managers all access the same object and dataset instead of requesting the same data from the server multiple times. Examples of this behavior were multiple calls to user/profile and issuer/issuers when starting on the /issuer route. 

Also made some changes to the newsletter component and the auth guard, where api services were called directly.

It seems like the CommonEntityManager class might have been created for this use case initially but has not been used consistently