### PR TITLE
Fix ui issues in micro degree view (#1090)

### DIFF
--- a/src/app/public/components/learningpath/learningpath.component.html
+++ b/src/app/public/components/learningpath/learningpath.component.html
@@ -121,10 +121,10 @@
 							</div>
 							<div
 								*ngIf="learningPath.completed_badges"
-								class="tw-flex md:tw--space-x-6 tw--space-x-4 tw-pt-4 pt-pb-4"
+								class="tw-flex tw-overflow-x-auto tw-overflow-y-hidden tw-w-full md:tw--space-x-6 tw--space-x-4 tw-pt-4 pt-pb-4"
 							>
 								<div
-									class="hover:tw-scale-105 hover:tw-z-10 tw-transform tw-ease-in-out tw-transition tw-duration-200"
+									class="tw-flex-shrink-0 hover:tw-scale-105 hover:tw-z-10 tw-transform tw-ease-in-out tw-transition tw-duration-200"
 									*ngFor="let badge of learningPath.completed_badges"
 								>
 									<img

--- a/src/app/public/components/learningpath/learningpath.component.html
+++ b/src/app/public/components/learningpath/learningpath.component.html
@@ -96,9 +96,7 @@
 						<div class="tw-absolute tw-flex tw-flex-col tw-w-full tw-text-right tw-right-4">
 							<span hlmH1 class="tw-font-extrabold tw-text-purple">{{ progressValue() }} %</span>
 							<span hlmP class="tw-mt-2 tw-text-oebblack tw-flex tw-justify-end">
-								<span [countUp]="hoursCompleted"></span>
-								<span>:</span>
-								<span [countUp]="minutesCompletedRemainder"></span>
+								<span [countUp]="minutesCompleted" [options]="{ formattingFn: formatCountUpMinutes }"></span>
 								<span> / </span>
 								<span> {{ minutesTotal | hourPipe }} h</span>
 							</span>

--- a/src/app/public/components/learningpath/learningpath.component.ts
+++ b/src/app/public/components/learningpath/learningpath.component.ts
@@ -22,6 +22,7 @@ import { SessionService } from '../../../common/services/session.service';
 import { PdfService } from '../../../common/services/pdf.service';
 import { RecipientBadgeManager } from '../../../recipient/services/recipient-badge-manager.service';
 import { RecipientBadgeInstance } from '../../../recipient/models/recipient-badge.model';
+import { HourPipe } from '../../../common/pipes/hourPipe';
 
 @Component({
 	templateUrl: './learningpath.component.html',
@@ -194,8 +195,6 @@ export class PublicLearningPathComponent implements OnInit, AfterContentInit {
 				(acc, b) => acc + b.extensions['extensions:StudyLoadExtension'].StudyLoad,
 				0,
 			);
-			this.hoursCompleted = Math.floor(this.minutesCompleted / 60);
-			this.minutesCompletedRemainder = this.minutesCompleted % 60;
 			this.issuerLoaded = this.publicService.getIssuer(response.issuer_id).then((issuer) => {
 				this.issuer = issuer;
 			});
@@ -204,6 +203,11 @@ export class PublicLearningPathComponent implements OnInit, AfterContentInit {
 				return badge;
 			});
 		});
+	}
+
+	formatCountUpMinutes(x: number) {
+		const p = new HourPipe();
+		return p.transform(x);
 	}
 
 	downloadPdf() {


### PR DESCRIPTION
Two changes here as requested in the issue:
1. The number of completed hours/minutes is now formatted according to the `hourPipe` implementation and thus equal to the total number of hours required for the micro degree
2. When there are many badges in a micro degree, the display of earned badges in the progress now overflows by scrolling horizontally if necessary.

Related issue: #1090 