### PR TITLE
fix: hide my institutions nav option when unverified

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -228,7 +228,7 @@
 						<svg class="navitem-x-icon" icon="icon_dropdown"></svg>
 					</a>
 
-					<a class="oeb-navitem" routerLinkActive="oeb-navitem-is-active" [routerLink]="['/issuer']">{{
+					<a class="oeb-navitem" routerLinkActive="oeb-navitem-is-active" *ngIf="showIssuersTab()" [routerLink]="['/issuer']">{{
 						'NavItems.myInstitutions' | translate
 					}}</a>
 
@@ -345,7 +345,7 @@
 			<hr class="mobilenav-x-rule" />
 			<a [routerLink]="['/recipient/badges']">{{ 'General.backpack' | translate }}</a>
 			<!-- <a [routerLink]="['/recipient/badge-collections']">{{ 'General.collections' | translate }}</a> -->
-			<a [routerLink]="['/issuer']" *ngIf="showIssuersTab">{{ 'NavItems.myInstitutions' | translate }}</a>
+			<a [routerLink]="['/issuer']" *ngIf="showIssuersTab()">{{ 'NavItems.myInstitutions' | translate }}</a>
 
 			<hr class="mobilenav-x-rule" *ngIf="launchpoints?.length" />
 			<p class="mobilenav-x-label" *ngIf="launchpoints?.length">Apps</p>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -228,9 +228,13 @@
 						<svg class="navitem-x-icon" icon="icon_dropdown"></svg>
 					</a>
 
-					<a class="oeb-navitem" routerLinkActive="oeb-navitem-is-active" *ngIf="showIssuersTab()" [routerLink]="['/issuer']">{{
-						'NavItems.myInstitutions' | translate
-					}}</a>
+					<a
+						class="oeb-navitem"
+						routerLinkActive="oeb-navitem-is-active"
+						*ngIf="showIssuersTab()"
+						[routerLink]="['/issuer']"
+						>{{ 'NavItems.myInstitutions' | translate }}</a
+					>
 
 					<!-- Account Menu -->
 					<oeb-dropdown

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, OnInit, Renderer2, ViewChild, Inject } from '@angular/core';
+import { AfterViewInit, Component, OnInit, Renderer2, ViewChild, Inject, signal } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -119,6 +119,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 	launchpoints?: ApiExternalToolLaunchpoint[];
 	issuers: Issuer[];
 	issuersLoaded: Promise<unknown>;
+	showIssuersTab = signal(false);
 
 	copyrightYear = new Date().getFullYear();
 
@@ -237,7 +238,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 		if (this.embedService.isEmbedded) {
 			// Enable the embedded indicator class on the body
 			renderer.addClass(document.body, 'embeddedcontainer');
-		}
+		}		
 	}
 
 	refreshProfile = () => {
@@ -245,30 +246,31 @@ export class AppComponent implements OnInit, AfterViewInit {
 			if (set.entities.length && set.entities[0].agreedTermsVersion !== set.entities[0].latestTermsVersion) {
 				this.commonDialogsService.newTermsDialog.openDialog();
 			}
+
+			// for issuers tab which can only be loaded when the user is verified
+			if(set.entities.length > 0 && set.entities[0].isVerified)
+				this.issuerManager.allIssuers$.subscribe(
+				(issuers) => {
+					this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+					this.shouldShowIssuersTab();
+				},
+				(error) => {
+					this.messageService.reportAndThrowError(this.translate.instant('Issuer.failLoadissuers'), error);
+				},
+			);
 		});
 
 		// Load the profile
 		this.profileManager.userProfileSet.ensureLoaded();
-
-		// for issuers tab
-		this.issuerManager.allIssuers$.subscribe(
-			(issuers) => {
-				this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-				this.shouldShowIssuersTab();
-			},
-			(error) => {
-				this.messageService.reportAndThrowError(this.translate.instant('Issuer.failLoadissuers'), error);
-			},
-		);
+		this.shouldShowIssuersTab();
 	};
 
 	dismissUnsupportedBrowserMessage() {
 		this.isUnsupportedBrowser = false;
 	}
 
-	showIssuersTab = false;
 	shouldShowIssuersTab = () =>
-		(this.showIssuersTab = !this.features.disableIssuers || (this.issuers && this.issuers.length > 0));
+		(this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0));
 
 	toggleMobileNav() {
 		this.mobileNavOpen = !this.mobileNavOpen;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -238,7 +238,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 		if (this.embedService.isEmbedded) {
 			// Enable the embedded indicator class on the body
 			renderer.addClass(document.body, 'embeddedcontainer');
-		}		
+		}
 	}
 
 	refreshProfile = () => {
@@ -248,16 +248,19 @@ export class AppComponent implements OnInit, AfterViewInit {
 			}
 
 			// for issuers tab which can only be loaded when the user is verified
-			if(set.entities.length > 0 && set.entities[0].isVerified)
+			if (set.entities.length > 0 && set.entities[0].isVerified)
 				this.issuerManager.allIssuers$.subscribe(
-				(issuers) => {
-					this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-					this.shouldShowIssuersTab();
-				},
-				(error) => {
-					this.messageService.reportAndThrowError(this.translate.instant('Issuer.failLoadissuers'), error);
-				},
-			);
+					(issuers) => {
+						this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+						this.shouldShowIssuersTab();
+					},
+					(error) => {
+						this.messageService.reportAndThrowError(
+							this.translate.instant('Issuer.failLoadissuers'),
+							error,
+						);
+					},
+				);
 		});
 
 		// Load the profile
@@ -270,7 +273,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 	}
 
 	shouldShowIssuersTab = () =>
-		(this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0));
+		this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0);
 
 	toggleMobileNav() {
 		this.mobileNavOpen = !this.mobileNavOpen;


### PR DESCRIPTION
This previously led to a 403 response by the api and thus to the interceptor picking it up. I found this during a e2e testing and figured that `showIssuersTab()` was actually fundamentally broken.