### PR TITLE
Fix/hide institutions when unverified

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -228,9 +228,13 @@
 						<svg class="navitem-x-icon" icon="icon_dropdown"></svg>
 					</a>
 
-					<a class="oeb-navitem" routerLinkActive="oeb-navitem-is-active" *ngIf="showIssuersTab()" [routerLink]="['/issuer']">{{
-						'NavItems.myInstitutions' | translate
-					}}</a>
+					<a
+						class="oeb-navitem"
+						routerLinkActive="oeb-navitem-is-active"
+						*ngIf="showIssuersTab()"
+						[routerLink]="['/issuer']"
+						>{{ 'NavItems.myInstitutions' | translate }}</a
+					>
 
 					<!-- Account Menu -->
 					<oeb-dropdown

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -228,13 +228,9 @@
 						<svg class="navitem-x-icon" icon="icon_dropdown"></svg>
 					</a>
 
-					<a
-						class="oeb-navitem"
-						routerLinkActive="oeb-navitem-is-active"
-						*ngIf="showIssuersTab()"
-						[routerLink]="['/issuer']"
-						>{{ 'NavItems.myInstitutions' | translate }}</a
-					>
+					<a class="oeb-navitem" routerLinkActive="oeb-navitem-is-active" *ngIf="showIssuersTab()" [routerLink]="['/issuer']">{{
+						'NavItems.myInstitutions' | translate
+					}}</a>
 
 					<!-- Account Menu -->
 					<oeb-dropdown

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -238,7 +238,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 		if (this.embedService.isEmbedded) {
 			// Enable the embedded indicator class on the body
 			renderer.addClass(document.body, 'embeddedcontainer');
-		}
+		}		
 	}
 
 	refreshProfile = () => {
@@ -248,19 +248,16 @@ export class AppComponent implements OnInit, AfterViewInit {
 			}
 
 			// for issuers tab which can only be loaded when the user is verified
-			if (set.entities.length > 0 && set.entities[0].isVerified)
+			if(set.entities.length > 0 && set.entities[0].isVerified)
 				this.issuerManager.allIssuers$.subscribe(
-					(issuers) => {
-						this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-						this.shouldShowIssuersTab();
-					},
-					(error) => {
-						this.messageService.reportAndThrowError(
-							this.translate.instant('Issuer.failLoadissuers'),
-							error,
-						);
-					},
-				);
+				(issuers) => {
+					this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+					this.shouldShowIssuersTab();
+				},
+				(error) => {
+					this.messageService.reportAndThrowError(this.translate.instant('Issuer.failLoadissuers'), error);
+				},
+			);
 		});
 
 		// Load the profile
@@ -273,7 +270,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 	}
 
 	shouldShowIssuersTab = () =>
-		this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0);
+		(this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0));
 
 	toggleMobileNav() {
 		this.mobileNavOpen = !this.mobileNavOpen;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -238,7 +238,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 		if (this.embedService.isEmbedded) {
 			// Enable the embedded indicator class on the body
 			renderer.addClass(document.body, 'embeddedcontainer');
-		}		
+		}
 	}
 
 	refreshProfile = () => {
@@ -248,16 +248,19 @@ export class AppComponent implements OnInit, AfterViewInit {
 			}
 
 			// for issuers tab which can only be loaded when the user is verified
-			if(set.entities.length > 0 && set.entities[0].isVerified)
+			if (set.entities.length > 0 && set.entities[0].isVerified)
 				this.issuerManager.allIssuers$.subscribe(
-				(issuers) => {
-					this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-					this.shouldShowIssuersTab();
-				},
-				(error) => {
-					this.messageService.reportAndThrowError(this.translate.instant('Issuer.failLoadissuers'), error);
-				},
-			);
+					(issuers) => {
+						this.issuers = issuers.slice().sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+						this.shouldShowIssuersTab();
+					},
+					(error) => {
+						this.messageService.reportAndThrowError(
+							this.translate.instant('Issuer.failLoadissuers'),
+							error,
+						);
+					},
+				);
 		});
 
 		// Load the profile
@@ -270,7 +273,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 	}
 
 	shouldShowIssuersTab = () =>
-		(this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0));
+		this.showIssuersTab.set(!this.features.disableIssuers && this.issuers && this.issuers.length > 0);
 
 	toggleMobileNav() {
 		this.mobileNavOpen = !this.mobileNavOpen;

--- a/src/app/issuer/components/issuer-list/issuer-list.component.html
+++ b/src/app/issuer/components/issuer-list/issuer-list.component.html
@@ -13,7 +13,7 @@
 				</p>
 
 				<p hlmP size="lg" class="tw-pb-3" [innerHTML]="'Issuer.myLearningPathText' | translate"></p>
-				<section *ngIf="issuers.length === 0" class="tw-flex tw-flex-col tw-gap-2 tw-mt-2">
+				<section *ngIf="issuers?.length === 0" class="tw-flex tw-flex-col tw-gap-2 tw-mt-2">
 					<span
 						[innerHTML]="'Issuer.createFirstInstitution' | translate"
 						class="tw-text-2xl tw-italic tw-text-oebblack"
@@ -30,7 +30,7 @@
 			</div>
 			<div class="tw-border-purple tw-border tw-rounded-[20px] md:tw-text-right tw-text-center tw-max-w-[600px]">
 				<oeb-button
-					*ngIf="issuers.length > 0"
+					*ngIf="issuers?.length > 0"
 					class="md:tw-whitespace-nowrap"
 					variant="secondary"
 					[routerLink]="['/issuer/create']"
@@ -191,7 +191,7 @@
 				></ng-container>
 			</div>
 		</div>
-		<section class="tw-flex tw-flex-col tw-gap-2" [ngClass]="issuers.length > 0 ? 'tw-mt-12' : ''">
+		<section class="tw-flex tw-flex-col tw-gap-2" [ngClass]="issuers?.length > 0 ? 'tw-mt-12' : ''">
 			<span [innerHTML]="'Issuer.partOfInstitution' | translate" class="tw-text-2xl tw-italic tw-text-oebblack">
 			</span>
 			<section
@@ -354,7 +354,7 @@
 
 <ng-template #pluginBoxTemplate let-showWhenEmpty="showWhenEmpty" let-mobile="mobile">
 	<div
-		*ngIf="(issuers.length === 0 && showWhenEmpty) || (issuers.length > 0 && !showWhenEmpty)"
+		*ngIf="(issuers?.length === 0 && showWhenEmpty) || (issuers?.length > 0 && !showWhenEmpty)"
 		#pluginBox
 		class="md:tw-flex-[0_0_363px] md:tw-mt-0 tw-mt-6"
 		[class.md:tw-w-[400px]]="mobile === false && showWhenEmpty"


### PR DESCRIPTION
Follow up from #1219 :

It turned out that now the "Meine Institutionen" button wasn't shown for verified users either.

I refactored the `showIssuersTab` method to use a computed signal, eliminating the need for calling `shouldShowIssuersTab` entirely.
I also moved the loading promise into a call thats similar to the login page, where the verification status is properly fetched.

Now it seems to work the way it is intended.
Actually found that this might resolve #1170