### PR TITLE
Fix: Disable QR Code Generate Button on Click

### DIFF
--- a/src/app/components/oeb-button.component.ts
+++ b/src/app/components/oeb-button.component.ts
@@ -1,94 +1,106 @@
-import { Component, Input, input } from '@angular/core';
-import { HlmButtonDirective } from './spartan/ui-button-helm/src';
+import { Component, computed, Input, input, linkedSignal, signal } from '@angular/core';
+import { buttonVariants, ButtonVariants, HlmButtonDirective } from './spartan/ui-button-helm/src';
 import { NgIf, NgClass } from '@angular/common';
 import { MessageService } from '../common/services/message.service';
 import { lucidePlus, lucideUpload, lucideCircleX, lucideMapPin } from '@ng-icons/lucide';
 import { provideIcons } from '@ng-icons/core';
 import { HlmIconDirective } from './spartan/ui-icon-helm/src';
 import { NgIcon } from '@ng-icons/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { map, Subscription } from 'rxjs';
 
 @Component({
 	selector: 'oeb-button',
 	imports: [HlmButtonDirective, HlmIconDirective, NgIf, NgClass, NgIcon],
 	providers: [MessageService, provideIcons({ lucideUpload, lucidePlus, lucideCircleX, lucideMapPin })],
 	template: `<button
-		[type]="type"
+		[type]="type()"
 		class="tw-relative"
 		hlmBtn
-		[disabled]="disabled"
-		[width]="width"
-		[size]="size"
-		[variant]="variant"
-		[attr.id]="id"
+		[disabled]="computedDisabled()"
+		[width]="width()"
+		[size]="size()"
+		[variant]="variant()"
+		[attr.id]="id()"
 	>
-		<ng-icon hlm *ngIf="icon" [ngClass]="{ 'tw-mr-4': iconLeft }" size="lg" [name]="icon" />
-		<img *ngIf="img" class="md:tw-h-[30px] tw-h-[20px] tw-pr-4" [src]="img" />
-		<span
-			[ngClass]="{ 'tw-text-[15px]': fontSize15 }"
-			[innerHTML]="showLoadingMessage && loadingMessage ? loadingMessage : text"
-		></span>
-	</button> `,
+		<ng-icon hlm *ngIf="icon()" [ngClass]="{ 'tw-mr-4': iconLeft() }" size="lg" [name]="icon()" />
+		<img *ngIf="img()" class="md:tw-h-[30px] tw-h-[20px] tw-pr-4" [src]="img()" />
+		<span [innerHTML]="computedText()"></span>
+	</button>`,
 })
 export class OebButtonComponent {
-	loadingPromise: Promise<unknown>;
-	promiseLoading = false;
+	readonly variant = input<ButtonVariants['variant']>('default');
+	readonly size = input<ButtonVariants['size']>('default');
+	readonly width = input<ButtonVariants['width']>('default');
+	readonly disabled = input<boolean>(false);
+	readonly text = input<string>();
+	readonly img = input<string>();
+	readonly icon = input<string>();
+	readonly type = input<'submit' | 'reset' | 'button'>('submit');
+	readonly id = input<string>();
+	readonly iconLeft = input<boolean>(false);
 
-	@Input() variant: string = 'default';
-	@Input() size: string = 'default';
-	@Input() width: string = 'default';
-	@Input() disabled: boolean = false;
-	@Input() text: string = undefined;
-	@Input() img: string = undefined;
-	@Input() icon: string = undefined;
-	@Input() type: string = 'submit';
-	@Input() id: string = null;
-	@Input() fontSize15: boolean = false;
-	@Input() iconLeft: boolean = false;
+	readonly loadingMessage = input<string>('Loading', { alias: 'loading-message' });
+	readonly loadingWhenRequesting = input<boolean>(false, { alias: 'loading-when-requesting' });
+	readonly disableWhenRequesting = input<boolean>(false, { alias: 'disabled-when-requesting' });
+	readonly loadingPromise = input<Promise<unknown> | Promise<unknown>[]>(undefined, { alias: 'loading-promises' });
+	readonly loadingPromise$ = toObservable(this.loadingPromise);
+	readonly promiseIsLoading = signal(false);
+	private loadingSubscription?: Subscription;
 
-	@Input('disabled-when-requesting')
-	disabledWhenRequesting = false;
+	readonly computedDisabled = computed(
+		() => this.disabled() || (this.disableWhenRequesting() && this.promiseIsLoading()),
+	);
 
-	@Input('loading-when-requesting')
-	loadingWhenRequesting = false;
+	readonly computedText = computed(() => {
+		return this.showLoadingMessage() && this.loadingMessage() ? this.loadingMessage() : this.text();
+	});
+	readonly showLoadingMessage = computed(
+		() => this.promiseIsLoading() || (this.loadingWhenRequesting() && this.messageService.pendingRequestCount > 0),
+	);
 
-	@Input('loading-message')
-	loadingMessage = 'Loading';
-
-	@Input('loading-promises')
-	set inputPromises(promises: Promise<unknown> | Array<Promise<unknown>> | null) {
-		this.updatePromises(promises ? (Array.isArray(promises) ? promises.filter((p) => !!p) : [promises]) : []);
-	}
-
-	get showLoadingMessage() {
-		return this.promiseLoading || (this.loadingWhenRequesting && this.messageService.pendingRequestCount > 0);
-	}
-
-	get disabledForLoading() {
-		return this.showLoadingMessage || (this.disabledWhenRequesting && this.messageService.pendingRequestCount > 0);
-	}
-
-	private updatePromises(promises: Array<Promise<unknown>>) {
-		if (promises.length === 0) {
-			this.loadingPromise = null;
-			this.promiseLoading = false;
-		} else {
-			const ourPromise = (this.loadingPromise = Promise.all(promises));
-
-			this.promiseLoading = true;
-
-			ourPromise.then(
-				() => {
-					if (ourPromise === this.loadingPromise) {
-						this.promiseLoading = false;
-					}
-				},
-				() => {
-					if (ourPromise === this.loadingPromise) {
-						this.promiseLoading = false;
-					}
-				},
-			);
-		}
-	}
 	constructor(private messageService: MessageService) {}
+
+	ngOnInit() {
+		// Subscribe to changes made to the loadingPromises
+		let currentLoadingPromise: Promise<unknown[]>;
+		this.loadingSubscription = this.loadingPromise$
+			.pipe(map((p) => this.transformPromisesInput(p)))
+			.subscribe((p) => {
+				currentLoadingPromise = p;
+				if (p === null) {
+					// loading promises have been removed from component, hence we are not loading anymore
+					this.promiseIsLoading.set(false);
+				} else {
+					this.promiseIsLoading.set(true);
+					p.then((_) => {
+						if (currentLoadingPromise === p) this.promiseIsLoading.set(false);
+					});
+				}
+			});
+	}
+
+	ngOnDestroy() {
+		this.loadingSubscription.unsubscribe();
+	}
+
+	/**
+	 * Transforms the promises input {@link loadingPromise} on the component into a single
+	 * promise that can be used to decide whether the button should be disabled or not.
+	 * This handles both single promises as well as arrays of promises attached to
+	 * the components input.
+	 * @param input Input to the component
+	 * @returns Promise to be used to decide whether to disable the button or null if
+	 * there are no promises in the input.
+	 */
+	transformPromisesInput(input: any): Promise<unknown[]> | null {
+		if (!input) return null;
+
+		let promises: Array<Promise<unknown>> = [];
+		if (Array.isArray(input)) promises = [...input.filter((p) => !!p && typeof p.then === 'function')];
+		else if (!!input && typeof input.then === 'function') promises = [input];
+
+		if (promises.length === 0) return null;
+		else return Promise.allSettled(promises); // allSettled -> we don't care if the promises are successful or not
+	}
 }

--- a/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
+++ b/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
@@ -140,6 +140,8 @@
 					class="tw-whitespace-nowrap tw-mt-6"
 					type="submit"
 					text="QR-Code generieren"
+					[loading-promises]="qrCodePromise"
+					disabled-when-requesting="true"
 				>
 				</oeb-button>
 			</div>

--- a/src/app/issuer/components/edit-qr-form/edit-qr-form.component.ts
+++ b/src/app/issuer/components/edit-qr-form/edit-qr-form.component.ts
@@ -14,6 +14,7 @@ import { SuccessDialogComponent } from '../../../common/dialogs/oeb-dialogs/succ
 import { TranslateService } from '@ngx-translate/core';
 import { DatePipe } from '@angular/common';
 import { Location } from '@angular/common';
+import { ApiQRCode } from '../../models/qrcode-api.model';
 
 @Component({
 	selector: 'edit-qr-form',
@@ -24,6 +25,8 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent {
 	static datePipe = new DatePipe('de');
 
 	@Input() editing: boolean = false;
+
+	qrCodePromise : Promise<any> | null = null;
 
 	get issuerSlug() {
 		return this.route.snapshot.params['issuerSlug'];
@@ -147,7 +150,7 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent {
 
 		if (this.editing) {
 			const formState = this.qrForm.value;
-			this.qrCodeApiService
+			this.qrCodePromise = this.qrCodeApiService
 				.updateQrCode(this.issuerSlug, this.badgeSlug, this.qrSlug, {
 					title: formState.title,
 					createdBy: formState.createdBy,
@@ -171,8 +174,7 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent {
 				});
 		} else {
 			const formState = this.qrForm.value;
-
-			this.qrCodeApiService
+			this.qrCodePromise = this.qrCodeApiService
 				.createQrCode(this.issuerSlug, this.badgeSlug, {
 					title: formState.title,
 					createdBy: formState.createdBy,


### PR DESCRIPTION
Issue: #1220 

I have refactored the `oeb-button` component and made it use signals and observables.
Afterwards a promise was added to the inputs of the `oeb-button` used to generate the qr code, which is now disabled once clicked.

@jona159 Regarding the issue I think we are done here. However, I do see some refactoring to be done still.
During the switch to signals I noticed that there are some sort of cryptic inputs that can be set on the button.
They seem to be widely used in the app but don't have any effect whatsoever.

I am specifically looking at `disabled-when-requesting`, which in the original implementation would _never_ disable the button at all, rendering it completely useless.
Also `loading-when-requesting` is used quite a bit and somehow involves the `MessageService` as a side effect.
I am not sure if this is used at all, but we should get this straight imho.

Could you give some input to this?
Should we get rid of some inputs?
Should `disabled-when-requesting` not be done implicitly, e.g. when a `loading-promise` is set and is executing, it could implicitly disable the button.
Otherwise you can always use `disabled` as a property and set it from the outside if necessary.