### PR TITLE
feat: highlight invalid untouched inputs when submitting a form

### DIFF
--- a/src/app/auth/components/login/login.component.html
+++ b/src/app/auth/components/login/login.component.html
@@ -53,7 +53,6 @@
 							fieldType="password"
 							placeholder="Dein Passwort"
 							fieldType="password"
-							[autofocus]="true"
 							#passwordField
 						>
 							<span label-additions>

--- a/src/app/components/spartan/ui-input-helm/src/lib/hlm-input.directive.ts
+++ b/src/app/components/spartan/ui-input-helm/src/lib/hlm-input.directive.ts
@@ -13,7 +13,7 @@ export const inputVariants = cva(
 				lg: 'tw-h-11 tw-px-8',
 			},
 			error: {
-				auto: '[&.ng-invalid.ng-touched]:tw-text-destructive [&.ng-invalid.ng-touched]:tw-border-destructive [&.ng-invalid.ng-touched]:focus-visible:tw-ring-destructive',
+				auto: '[&.ng-invalid.ng-touched]:tw-text-destructive [&.ng-invalid.ng-touched]:tw-border-destructive [&.ng-invalid.ng-touched]:focus-visible:tw-ring-destructive [&.ng-invalid.ng-dirty]:tw-text-destructive [&.ng-invalid.ng-dirty]:tw-border-destructive [&.ng-invalid.ng-dirty]:focus-visible:tw-ring-destructive',
 				true: 'tw-text-destructive tw-border-destructive focus-visible:tw-ring-destructive',
 			},
 		},

--- a/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
+++ b/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
@@ -38,7 +38,6 @@
 					label="Name Ersteller:in"
 					[placeholder]="'Mein Vorname und Nachname'"
 					fieldType="text"
-					[autofocus]="true"
 					[control]="qrForm.rawControlMap.createdBy"
 				></oeb-input>
 				<input [formControl]="qrForm.rawControlMap.badgeclass_id" type="hidden" />

--- a/src/app/issuer/components/learningpath-create-steps/learningpath-details/learningpath-details.component.html
+++ b/src/app/issuer/components/learningpath-create-steps/learningpath-details/learningpath-details.component.html
@@ -6,9 +6,6 @@
 			label="1. Micro Degree-Titel"
 			[control]="lpDetailsForm.rawControlMap.name"
 			[autofocus]="true"
-			[errorMessage]="{
-				required: 'Required'
-			}"
 			sublabelRight="(max. 60 Zeichen)"
 		></oeb-input>
 		<oeb-input
@@ -17,6 +14,7 @@
 			[fieldType]="'textarea'"
 			sublabelRight="(max. 700 Zeichen)"
 			placeholder="{{ 'LearningPathEditor.shortDescription' | translate }}"
+			
 		></oeb-input>
 
 		<div class="tw-mt-6 md:tw-mt-7 tw-relative" id="imageSection" #imageSection>

--- a/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
+++ b/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
@@ -67,7 +67,7 @@ export class LearningPathEditFormComponent extends BaseAuthenticatedRoutableComp
 	@ViewChild('stepFour') stepFour!: LearningPathTagsComponent;
 
 	nextStep(): void {
-		// this.learningPathForm.markTreeDirtyAndValidate();
+		this.learningPathForm.markTreeDirtyAndValidate();
 		this.stepper.next();
 	}
 


### PR DESCRIPTION
Issue: #1218 

Changes made:
`<oeb-input/>`/`hlmInput` component now turns to the error style when its either invalid and touched or invalid and dirty. This is required for when forms are submitted without the user ever focusing one of the inputs (they become dirty but stay untouched).
Previously they would stay in their regular color instead of being highlighted.

The form in question in the issue is now marked dirty on submit, thus highlighting missing fields as a result of the above change.

I reviewed (hopefully) all other forms to check if this had any unwanted side effects, which it didn't. It actually applies the effect correctly to other forms now as well.
Two forms showed one highlighted field on page load. Those turned out to have two components with `[autofocus]="true"`, which makes the first input go to the touched state.
To prevent that and focus the first field correctly, I removed the second `[autofocus]="true"`.