### PR TITLE
Fix/competency duration warning

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -835,7 +835,7 @@
 															<oeb-input
 																id="{{ 'competencyDurationHour_' + i }}"
 																[fieldType]="'number'"
-																class="tw-max-w-36"
+																class="tw-max-w-40"
 																[control]="competency.rawControlMap.hours"
 																[errorMessage]="{
 																	max: maxValue1000
@@ -847,7 +847,7 @@
 															<oeb-input
 																id="{{ 'competencyDurationMinutes_' + i }}"
 																[fieldType]="'number'"
-																class="tw-max-w-36"
+																class="tw-max-w-40"
 																[control]="competency.rawControlMap.minutes"
 																[errorMessage]="{
 																	max: minMaxError

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -835,10 +835,10 @@
 															<oeb-input
 																id="{{ 'competencyDurationHour_' + i }}"
 																[fieldType]="'number'"
-																class="tw-max-w-24"
+																class="tw-max-w-36"
 																[control]="competency.rawControlMap.hours"
 																[errorMessage]="{
-																	duration: requiredError
+																	max: maxValue1000
 																}"
 																noTopMargin="true"
 															>
@@ -847,10 +847,10 @@
 															<oeb-input
 																id="{{ 'competencyDurationMinutes_' + i }}"
 																[fieldType]="'number'"
-																class="tw-max-w-24"
+																class="tw-max-w-36"
 																[control]="competency.rawControlMap.minutes"
 																[errorMessage]="{
-																	duration: requiredError
+																	max: minMaxError
 																}"
 																noTopMargin="true"
 															>

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -62,6 +62,9 @@ import { BadgeClassDetailsComponent } from '../badgeclass-create-steps/badgeclas
 import { Issuer } from '../../models/issuer.model';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
+const MAX_STUDYLOAD_HRS: number = 10_000;
+const MAX_HRS_PER_COMPETENCY: number = 1_000;
+
 @Component({
 	selector: 'badgeclass-edit-form',
 	templateUrl: './badgeclass-edit-form.component.html',
@@ -70,7 +73,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs';
 })
 export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableComponent implements OnInit, AfterViewInit {
 	private readonly _hlmDialogService = inject(HlmDialogService);
-
+	
 	baseUrl: string;
 	badgeCategory: string;
 
@@ -298,7 +301,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 			typedFormGroup()
 				.addControl('selected', false)
 				.addControl('studyLoad', 60, [Validators.required, this.positiveInteger])
-				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(999)])
+				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(MAX_HRS_PER_COMPETENCY)])
 				.addControl('minutes', 0, [this.positiveIntegerOrNull, Validators.max(59)])
 				.addControl('framework', 'esco', Validators.required),
 		)
@@ -306,7 +309,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 			'keywordCompetencies',
 			typedFormGroup()
 				.addControl('studyLoad', 60, [Validators.required, this.positiveInteger])
-				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(999)])
+				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(MAX_HRS_PER_COMPETENCY)])
 				.addControl('minutes', 0, [this.positiveIntegerOrNull, Validators.max(59)])
 				.addControl('framework', 'esco', Validators.required),
 		)
@@ -319,7 +322,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 				.addControl('framework_identifier', '')
 				// limit of 1000000 is set so that users cant break the UI by entering a very long number
 				.addControl('studyLoad', 60, [Validators.required, this.positiveInteger])
-				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(999)])
+				.addControl('hours', 1, [this.positiveIntegerOrNull, Validators.max(MAX_HRS_PER_COMPETENCY)])
 				.addControl('minutes', 0, [this.positiveIntegerOrNull, Validators.max(59)])
 				.addControl('category', '', Validators.required)
 				.addControl('framework', '')
@@ -1149,7 +1152,7 @@ export class BadgeClassEditFormComponent extends BaseAuthenticatedRoutableCompon
 			return { maxMinutesError: true };
 		}
 		const hours = value.badge_hours;
-		if (hours > 10000) {
+		if (hours > MAX_STUDYLOAD_HRS) {
 			return { maxHoursError: true };
 		}
 	}

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -63,7 +63,7 @@ import { Issuer } from '../../models/issuer.model';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 
 const MAX_STUDYLOAD_HRS: number = 10_000;
-const MAX_HRS_PER_COMPETENCY: number = 1_000;
+const MAX_HRS_PER_COMPETENCY: number = 999;
 
 @Component({
 	selector: 'badgeclass-edit-form',

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -450,7 +450,7 @@
 		"addAnotherCompetency": "Weitere Kompetenz hinzufügen",
 		"giveBadgeTitle": "Bitte gib dem Badge einen Titel",
 		"changeBadgeTitle": "Bitte ändere den Titel",
-		"maxValue1000": "Maximalwert ist 1000",
+		"maxValue1000": "Muss kleiner als 1000 sein",
 		"imageTooLarge": "Das Bild ist zu groß. Bitte wähle ein Bild mit einer Größe von maximal 2 MB.",
 		"licenseInfo": "Badges werden unter der <a class='tw-underline tw-text-[#1400FF]' target='_blank' href='https://creativecommons.org/publicdomain/zero/1.0/legalcode.de'> Lizenz CC0 1.0</a> erstellt.",
 		"requiredError": "Erforderlich",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -387,7 +387,7 @@
 		"addAnotherCompetency": "Add another competency",
 		"giveBadgeTitle": "Please give the badge a title",
 		"changeBadgeTitle": "Please change the title",
-		"maxValue1000": "Maximum value is 1000",
+		"maxValue1000": "Must be less than 1000",
 		"imageTooLarge": "The image is too large. Please select an image with a size of up to 2 MB.",
 		"licenseInfo": "Badges are created under the license <a class='tw-underline tw-text-[#1400FF]' target='_blank' href='https://creativecommons.org/publicdomain/zero/1.0/legalcode.de'>CC BY 4.0'</a>.",
 		"requiredError": "Required",


### PR DESCRIPTION
Issue: #1112 

The validation was reporting with a generic error message that states that the "max" validation was failing.
It turned out to be just that.
Now the correct error messages are shown:
![image](https://github.com/user-attachments/assets/2f52fae8-9032-4ab1-b952-613cf1408bac)

I have made the fields a little wider so the error message do not overlap.
I also introduced some constants so we have less magic numbers in the code.