### PR TITLE
Feat/role dependent buttons

### DIFF
--- a/src/app/components/datatable-learningpaths.component.ts
+++ b/src/app/components/datatable-learningpaths.component.ts
@@ -60,8 +60,8 @@ import { Issuer } from '../issuer/models/issuer.model';
 					width="full_width"
 					(click)="actionElement.emit(learningPath.slug)"
 					[text]="actionElementText"
-					[disabled]="!issuer.canCreateBadge"
-					[class]="issuer.canCreateBadge ? '' : 'disabled'"
+					[disabled]="!issuer.canDeleteBadge"
+					[class]="issuer.canDeleteBadge ? '' : 'disabled'"
 				></oeb-button>
 			</hlm-th>
 		</hlm-trow>

--- a/src/app/components/oeb-dropdown.component.ts
+++ b/src/app/components/oeb-dropdown.component.ts
@@ -31,10 +31,14 @@ import { SharedIconsModule } from '../public/icons.module';
 		SharedIconsModule,
 	],
 	template: `
-		<button [brnMenuTriggerFor]="menu">
+		<button
+			[brnMenuTriggerFor]="menu"
+			[disabled]="!hasEnabledMenuItem"
+			class="disabled:tw-pointer-events-none disabled:tw-opacity-50"
+		>
 			<ngTemplateOutlet *ngIf="isTemplate; else stringTrigger" [ngTemplateOutlet]="trigger"></ngTemplateOutlet>
 			<ng-template #stringTrigger>
-				<button [class]="triggerStyle">
+				<button [class]="triggerStyle" [disabled]="!hasEnabledMenuItem">
 					{{ trigger }}
 					<ng-icon hlm class="tw-ml-2" name="lucideChevronDown" hlmMenuIcon />
 				</button>
@@ -83,13 +87,18 @@ export class OebDropdownComponent {
 	@Input() trigger: any;
 	@Input() size: HlmMenuItemVariants['size'] = 'default';
 	@Input() inset: HlmMenuItemVariants['inset'] = false;
-	@Input() triggerStyle: string = 'tw-border tw-border-solid tw-border-purple tw-px-1 tw-py-2 tw-rounded-xl';
+	@Input() triggerStyle: string = 'tw-border tw-border-solid tw-border-purple tw-px-1 tw-py-2 tw-rounded-xl disabled:tw-pointer-events-none disabled:tw-opacity-50';
 	@Input() label?: string = '';
 	@Input() class?: string = '';
 	@Input() menuItems: MenuItem[];
 
 	get isTemplate(): boolean {
 		return this.trigger instanceof TemplateRef;
+	}
+
+	get hasEnabledMenuItem(): boolean {
+		if (this.menuItems === undefined || this.menuItems === null || this.menuItems.length === 0) return true;
+		return this.menuItems.find((m) => !m.disabled) !== undefined;
 	}
 
 	get iconClass(): string {

--- a/src/app/components/oeb-dropdown.component.ts
+++ b/src/app/components/oeb-dropdown.component.ts
@@ -45,7 +45,13 @@ import { SharedIconsModule } from '../public/icons.module';
 			<hlm-menu [size]="size" [inset]="inset" class="tw-border-[var(--color-purple)] tw-border-2">
 				<hlm-menu-label [size]="size" *ngIf="label">{{ label }}</hlm-menu-label>
 				<ng-container *ngFor="let menuItem of menuItems">
-					<button *ngIf="menuItem.action" (click)="menuItem.action($event)" [size]="size" hlmMenuItem>
+					<button
+						*ngIf="menuItem.action"
+						(click)="menuItem.action($event)"
+						[size]="size"
+						[disabled]="menuItem.disabled"
+						hlmMenuItem
+					>
 						<ng-icon hlm [size]="iconClass" *ngIf="menuItem.icon" name="{{ menuItem.icon }}" hlmMenuIcon />
 						{{ menuItem.title }}
 					</button>

--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
@@ -241,7 +241,7 @@ export class BadgeClassDetailComponent extends BaseAuthenticatedRoutableComponen
 						{
 							title: 'Bearbeiten',
 							routerLink: ['/issuer/issuers', this.issuerSlug, 'badges', this.badgeSlug, 'edit'],
-							disabled: this.badgeClass.recipientCount > 0,
+							disabled: this.badgeClass.recipientCount > 0 || !this.issuer.canEditBadge,
 							icon: 'lucidePencil',
 						},
 						{
@@ -252,6 +252,7 @@ export class BadgeClassDetailComponent extends BaseAuthenticatedRoutableComponen
 								});
 							},
 							icon: 'lucideCopy',
+							disabled: !this.issuer.canCreateBadge
 						},
 						{
 							title: 'Kopierstatus bearbeiten',
@@ -263,11 +264,13 @@ export class BadgeClassDetailComponent extends BaseAuthenticatedRoutableComponen
 								'copypermissions',
 							],
 							icon: 'lucideCopyX',
+							disabled: !this.issuer.canEditBadge
 						},
 						{
 							title: 'Löschen',
 							icon: 'lucideTrash2',
 							action: () => this.deleteBadge(),
+							disabled: !this.issuer.canDeleteBadge
 						},
 					],
 					badgeDescription: this.badgeClass.description,

--- a/src/app/issuer/models/issuer.model.ts
+++ b/src/app/issuer/models/issuer.model.ts
@@ -157,9 +157,33 @@ export class Issuer extends ManagedEntity<ApiIssuer, IssuerRef> {
 	 * - there is a logged in user
 	 * - the logged in user has either the owner or editor role for this issuer
 	 *
-	 * @returns {boolean}
+	 * @returns {boolean} true if the user may create badge, false otherwise
 	 */
 	get canCreateBadge(): boolean {
+		return this.apiModel.verified && (this.currentUserStaffMember?.canEditBadge ?? false);
+	}
+
+	/**
+	 * Evaluates if the current user may edit badges, which is the case if all of the
+	 * following conditions are fulfilled:
+	 * - the issuer is verified
+	 * - there is a logged in user
+	 * - the logged in user has either the owner or editor role for this issuer
+	 * @returns {boolean} true if the user may edit badges, false otherwise
+	 */
+	get canEditBadge(): boolean {
+		return this.apiModel.verified && (this.currentUserStaffMember?.canEditBadge ?? false);
+	}
+
+	/**
+	 * Evaluates if the current user may delete badges, which is the case if all of the
+	 * following conditions are fulfilled:
+	 * - the issuer is verified
+	 * - there is a logged in user
+	 * - the logged in user has either the owner or editor role for this issuer
+	 * @returns {boolean} true if the user may delete badges, false otherwise
+	 */
+	get canDeleteBadge(): boolean {
 		return this.apiModel.verified && (this.currentUserStaffMember?.canEditBadge ?? false);
 	}
 


### PR DESCRIPTION
Issue: #1151 

I have disabled the things a Mitarbeiter:in should not be able to do.
That includes editing, creating and deleting badges and the associated actions (like copying inside an institution, which required creating a badge and changing the copy status).

Because the oeb-dropdown that shows the menu options only contains disabled options for a Mitarbeiter:in, I have added a disabled state for the oeb-dropdown component to be able to disabled and grey out the entire component.
This should however not affect dropdowns that do not specify any menu items.