### PR TITLE
Fix/staging issues

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-copypermissions/badgeclass-edit-copypermissions.component.html
+++ b/src/app/issuer/components/badgeclass-edit-copypermissions/badgeclass-edit-copypermissions.component.html
@@ -21,7 +21,7 @@
 				<form [formGroup]="badgeClassForm.rawControl" #formElem (ngSubmit)="onSubmit()" novalidate>
 					<div class="section tw-text-oebblack tw-mt-6">
 						<h2 hlmH2 class="tw-font-bold">{{ 'Badge.copyBadgeHeadline' | translate }}</h2>
-						<p class="tw-text-purple tw-italic" [innerHTML]="'Badge.copyBadgeDescription' | translate"></p>
+						<p class="tw-text-purple tw-italic" [innerHTML]="('Badge.copyBadgeDescription1' | translate) + '<br />' +  ('Badge.copyBadgeDescription2' | translate)"></p>
 						<div class="tw-mt-2 tw-mb-2">
 							<oeb-checkbox
 								[control]="badgeClassForm.rawControlMap.copy_permissions_allow_others"

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -397,10 +397,6 @@
 		"award": "Badge direkt vergeben",
 		"awardQRCode": "Badge über QR-Code vergeben",
 		"partOfLearningPath": "Dieser Badge ist Teil folgender Micro Degrees:",
-		"creator": "Kampagnen-Ersteller:in",
-		"validity": "Gültigkeit des QR-Codes",
-		"download": "Download QR-Code",
-		"toBadgeDetail": "Zur Badge Detail-Seite",
 		"awardCriteria": "Vergabe-Kriterien",
 		"criteriaDesc": "Welche Anforderungen müssen deine Lernenden erfüllen, um den Badge zu erhalten?",
 		"activeParticipation": "Aktive Teilnahme",
@@ -680,6 +676,12 @@
 		"addEmailToUpload": "Füge die E-Mail-Adresse deinem Profil hinzu, um den Badge hochzuladen.",
 		"versionUploadInfo": "Momentan können leider nur Badges der Version 2.0 hochgeladen werden"
 	},
+	"EditBadge": {
+		"editBadge": "Badge editieren",
+		"editBadgeInfo": "Editiere die Information dieses Badges.",
+		"removeCompetency": "Kompetenz löschen",
+		"removeCompetencyInfo": "Möchtest du diese Kompetenz wirklich löschen?"
+	},
 	"RecBadgeDetail": {
 		"shareBadge": "Badge teilen",
 		"verify": "Verifizieren",
@@ -713,12 +715,6 @@
 		"deleteBadge": "Badge aus Rucksack löschen",
 		"copyShareLink": "Kopiere diesen Link zum teilen",
 		"addToProfile": "Zum Profil hinzufügen"
-	},
-	"EditBadge": {
-		"editBadge": "Badge editieren",
-		"editBadgeInfo": "Editiere die Information dieses Badges.",
-		"removeCompetency": "Kompetenz löschen",
-		"removeCompetencyInfo": "Möchtest du diese Kompetenz wirklich löschen?"
 	},
 	"BadgeCollection": {
 		"addCollection": "Sammlung hinzufügen",
@@ -853,6 +849,10 @@
 		"openRequestsOne": "1 offene Badge-Anfrage",
 		"openRequests": "{{ count }} offene Badge-Anfragen",
 		"showQrCode": "Zum QR-Code",
+		"creator": "Kampagnen-Ersteller:in",
+		"validity": "Gültigkeit des QR-Codes",
+		"download": "Download QR-Code",
+		"toBadgeDetail": "Zur Badge Detail-Seite",
 		"downloadPoster": "Download QR-Code-Plakat"
 	},
 	"LearningPath": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -384,7 +384,8 @@
 			"learningpath": "Micro Degree"
 		},
 		"copyBadgeHeadline": "Select copy status",
-		"copyBadgeDescription": "Within your own institution, badges can always be copied.<br>You can update the copy status for <strong>other</strong> institutions at any time later via the menu on the badge detail page.",
+		"copyBadgeDescription1": "Within your own institution, badges can always be copied.",
+		"copyBadgeDescription2": "You can update the copy status for <strong>other</strong> institutions at any time later via the menu on the badge detail page.",
 		"copyLabelOthers": "The badge may be copied by <strong>other</strong> institutions.",
 		"copy": "Copy badge for own institution",
 		"copyBadge": "Copy badge",
@@ -395,7 +396,19 @@
 		"editCopyStatus": "Edit copy status",
 		"award": "Award Badge",
 		"awardQRCode": "Award Badge using QR-Code",
-		"partOfLearningPath": "This Badge is part of the following Micro Degrees:"
+		"partOfLearningPath": "This Badge is part of the following Micro Degrees:",
+		"awardCriteria": "Award Criteria",
+		"criteriaDesc": "What requirements should your learners meet to receive the badge?",
+		"activeParticipation": "Active Participation",
+		"selfReflection": "Self-Reflection",
+		"achievedIndividualLearning": "Individual Learning Goal Achieved",
+		"presence90": "90% Attendance",
+		"practicalApplication": "Practical Application",
+		"onlineCourseCompleted": "Online Course Completed",
+		"projectCompleted": "Project Completed",
+		"addOwnCriteria": "Add Own Criterion",
+		"enterOwnCriteria": "Enter Own Criterion",
+		"enterOwnCriteriaDesc": "You can enter explanations here (max. 300 characters)"
 	},
 	"CreateBadge": {
 		"chooseBadgeCategory": "Choose category",
@@ -472,7 +485,6 @@
 		"maxValue1000": "Must be less than 1000",
 		"imageTooLarge": "The image is too large. Please choose an image with a maximum size of 2 MB.",
 		"licenseInfo": "Badges are created under the <a class='tw-underline tw-text-[#1400FF]' target='_blank' href='https://creativecommons.org/publicdomain/zero/1.0/legalcode.de'>CC0 1.0 license</a>.",
-
 		"requiredError": "Required",
 		"hoursMaxError": "Hours cannot exceed 10,000.",
 		"minMaxError": "Please enter a valid number of minutes (0 to 59).",
@@ -626,9 +638,9 @@
 	},
 	"RecBadge": {
 		"addBadge": "Add badge",
+		"uploadBadge": "Upload Badge",
 		"fromMozilla": "Is it from Mozilla?",
 		"closeNotification": "Close notification",
-		"uploadBadge": "Upload Badge",
 		"noBadgesYet": "You don't have any badges yet",
 		"noLearningPathYet": "You don't have any Micro Degrees yet",
 		"collectShareBadges": "Collect and share digital badges from your backpack.",


### PR DESCRIPTION
- Missing translations added
- Translations reordered s.t. english and german have the same structure
- Use a merge of myIssuers and allIssuers for `issuerBySlug` s.t. staff information is available for institutions coming from myIssuers

Some background on the issuers thing:
Staff information should not be available from the public (all issuers) endpoint, since this shouldn't be publicly available.
However, when part of an institution, you are allowed to see who is part of it.
Hence, the private endpoint (my issuers) returns that information.
`issuerBySlug` is used across the app and some things require the staff information (such as role info).
