### PR TITLE
fix(layout): enforce squareness on issuer images

### DIFF
--- a/src/app/common/components/badge-detail/badge-detail.component.html
+++ b/src/app/common/components/badge-detail/badge-detail.component.html
@@ -95,7 +95,7 @@
 							>
 								<div>
 									<img
-										class="tw-min-w-[37.1px] tw-h-[37.1px] md:tw-min-w-[53px] md:tw-h-[53px] issuer-image"
+										class="tw-min-w-[37.1px] tw-h-[37.1px] md:tw-min-w-[53px] md:tw-h-[53px] issuer-image tw-aspect-square"
 										[loaded-src]="config.issuerImage"
 										[loading-src]="config.issuerImagePlacholderUrl"
 										[error-src]="config.issuerImagePlacholderUrl"
@@ -120,7 +120,10 @@
 									>
 										<ng-template #collapseCriteriaTrigger>
 											<dt class="tw-mr-auto tw-flex tw-justify-center tw-items-center tw-px-2">
-												<ng-icon hlm name="lucideAward" class="tw-w-8 tw-h-8 tw-text-purple">
+												<ng-icon hlm name="lucideAward"
+													class="tw-w-8 tw-h-8 tw-text-purple"
+												>
+
 												</ng-icon>
 												<span
 													class="tw-text-oebblack tw-font-bold tw-text-sm tw-ml-1"

--- a/src/app/common/components/issuer/oeb-issuer-detail.component.html
+++ b/src/app/common/components/issuer/oeb-issuer-detail.component.html
@@ -6,7 +6,7 @@
 				[loading-src]="issuerPlaceholderSrc"
 				[error-src]="issuerPlaceholderSrc"
 				alt="{{ issuer.name }} avatar"
-				class="tw-h-[70px] md:tw-h-[100px] tw-w-auto tw-min-w-[70px] md:tw-min-w-[100px]"
+				class="tw-h-[70px] md:tw-h-[100px] tw-w-auto tw-min-w-[70px] md:tw-min-w-[100px] tw-aspect-square"
 			/>
 		</div>
 		<div class="tw-flex tw-flex-col tw-justify-center tw-pl-8 tw-max-w-[80%] oeb-break-words">

--- a/src/app/common/components/oeb-issuercard.ts
+++ b/src/app/common/components/oeb-issuercard.ts
@@ -9,7 +9,7 @@ import { Issuer } from '../../issuer/models/issuer.model';
 	template: `
 		<div class="tw-flex tw-flex-col tw-h-full">
 			<div class="tw-flex-row tw-flex tw-items-center">
-				<img [src]="issuer.image" width="80" />
+				<img [src]="issuer.image" class="tw-aspect-square" width="80"/>
 				<div class="tw-flex tw-flex-col tw-flex-wrap tw-pl-4 tw-py-2 tw-break-words">
 					<a [routerLink]="['/public/issuers', issuer.slug]" hlmP>{{ issuer.name }}</a>
 					<p class="tw-font-bold" hlmP size="sm">{{ issuer.email }}</p>

--- a/src/app/components/issuer-card/issuer-card.component.html
+++ b/src/app/components/issuer-card/issuer-card.component.html
@@ -3,7 +3,7 @@
 >
 	<div class="tw-flex tw-flex-row tw-gap-4">
 		<img
-			class="tw-w-24"
+			class="tw-w-24 tw-aspect-square"
 			[loaded-src]="issuer?.image"
 			[loading-src]="issuer?.imagePlaceholder"
 			[error-src]="issuer?.imagePlaceholder"

--- a/src/app/issuer/components/issuer-list/issuer-list.component.html
+++ b/src/app/issuer/components/issuer-list/issuer-list.component.html
@@ -123,7 +123,7 @@
 								[loading-src]="issuerPlaceholderSrc"
 								[error-src]="issuerPlaceholderSrc"
 								alt="{{ issuer.name }} avatar"
-								class="tw-h-[70px] md:tw-h-[100px] tw-w-auto tw-min-w-[70px] md:tw-min-w-[100px]"
+								class="tw-h-[70px] md:tw-h-[100px] tw-w-auto tw-min-w-[70px] md:tw-min-w-[100px] tw-aspect-square"
 							/>
 						</div>
 						<div class="tw-flex tw-flex-col tw-justify-center tw-pl-4 oeb-break-words">
@@ -256,7 +256,7 @@
 								(click)="selectIssuerFromDropdown(issuer)"
 								*ngFor="let issuer of issuerSearchResults"
 							>
-								<img [src]="issuer.image" width="24" height="24" />
+								<img [src]="issuer.image" width="24" class="tw-aspect-square" />
 								<span>{{ issuer.name }}</span>
 							</li>
 							<li


### PR DESCRIPTION
Issue: #1203 

This ensures all img tags that display issuer images do use `aspect-ratio: 1/1` leading to a square image no matter what.
Non-square images (which are actually not allowed but do exist historically) will get scaled down.