### PR TITLE
feat(ci): move format check to its own job and disable test job

### DIFF
--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -14,26 +14,34 @@ env:
     IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-    test:
-        name: 🧪 Test
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                node-version: [20.9.0]
-
-        steps:
-            - name: ⬇️  Checkout repository
-              uses: actions/checkout@v4.2.2
-            - name: 🔨 Setup node
-              uses: actions/setup-node@master
-              with:
-                  node-version: ${{ matrix.node-version }}
-            - name: 📲 Install dependencies
-              run: npm ci
-            - name: Format
-              run: npx prettier --check .
-            - name: 📝 Test
-              run: npm run test-headless
+    lint:
+      name: 🔍 Formatting & Linting
+      runs-on: ubuntu-latest
+      steps:
+        - name: ⬇️  Checkout repository
+          uses: actions/checkout@v4.2.2
+        - name: 🔨 Setup node
+          uses: actions/setup-node@v4.4.0
+          with:
+              node-version-file: '.nvmrc'
+        - name: 📲 Install dependencies
+          run: npm ci
+        - name: Prettier
+          run: npx prettier --check .
+    # test:
+    #     name: 🧪 Test
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - name: ⬇️  Checkout repository
+    #           uses: actions/checkout@v4.2.2
+    #         - name: 🔨 Setup node
+    #           uses: actions/setup-node@v4.4.0
+    #           with:
+    #               node-version-file: '.nvmrc'
+    #         - name: 📲 Install dependencies
+    #           run: npm ci
+    #         - name: 📝 Test
+    #           run: npm run test-headless
 
     create-release:
         permissions:


### PR DESCRIPTION
For issue #1319 

I have taken prettier out of the test stage and moved it into its own.
While at it, `setup-node` was quite outdated and got and update as well.
It now supports `node-file-version` and since we have an `.nvmrc` file, I switched to using that, so we can eventually manage our node version from a single file.