### PR TITLE
fix: workaround for old badges

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-copypermissions/badgeclass-edit-copypermissions.ts
+++ b/src/app/issuer/components/badgeclass-edit-copypermissions/badgeclass-edit-copypermissions.ts
@@ -112,6 +112,10 @@ export class BadgeClassEditCopyPermissionsComponent extends BaseAuthenticatedRou
 			copy_permissions.push('others');
 		}
 		this.badgeClass.copyPermissions = copy_permissions;
+		// the criteria field is null for old badges, leading to an error when trying to save
+		if (!this.badgeClass.criteria) {
+			this.badgeClass.criteria = [];
+		}
 		try {
 			this.savePromise = this.badgeClass.save();
 			await this.savePromise;


### PR DESCRIPTION
This PR is a workaround to allow saving the copy permissions of badges that were created before we updated the criteria field. Currently trying to save a badgeclass throws this error: 
```
criteria: This field may not be null."
```
because the criteria field is null for these old badges while it is an empty array for newer ones without criteria. 