### PR TITLE
feat: add copy selection dialog

### DIFF
--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
@@ -372,7 +372,9 @@ export class BadgeClassDetailComponent extends BaseAuthenticatedRoutableComponen
 							icon: 'lucidePencil',
 						},
 						{
-							title: 'Badge.copy',
+							title: this.badgeClass.copyPermissions.includes('others')
+								? 'General.copy'
+								: 'Badge.copyThisIssuer',
 							action: this.copyBadge.bind(this),
 							icon: 'lucideCopy',
 							disabled: !this.issuer.canCreateBadge,


### PR DESCRIPTION
The copy selection dialog only existed at the public badge detail page, this PR adds it to the issuer badge detail page as well