### PR TITLE
feat/private collection msg

### DIFF
--- a/src/app/public/components/badge-collection/badge-collection.component.html
+++ b/src/app/public/components/badge-collection/badge-collection.component.html
@@ -19,7 +19,7 @@
 	</div>
 
 	<!-- Regular View -->
-	<main *ngIf="!embedService.isEmbedded">
+	<main *ngIf="!embedService.isEmbedded && collection">
 		<div class="page-padding oeb">
 			<div class="tw-bg-lightpurple oeb-inset-padding">
 				<header class="oeb-section-sm">
@@ -71,5 +71,9 @@
 				</section>
 			</div>
 		</div>
+	</main>
+
+	<main *ngIf="!embedService.isEmbedded && !collection">
+		<bg-not-found-collection />
 	</main>
 </ng-template>

--- a/src/app/public/components/not-found-badge-collection/not-found-badge-collection.component.ts
+++ b/src/app/public/components/not-found-badge-collection/not-found-badge-collection.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { HlmIconDirective } from '../../../components/spartan/ui-icon-helm/src/lib/hlm-icon.directive';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCircleX } from '@ng-icons/lucide';
+import { TranslatePipe } from '@ngx-translate/core';
+
+@Component({
+	selector: 'bg-not-found-collection',
+	imports: [HlmIconDirective, NgIcon, TranslatePipe],
+	providers: [provideIcons({ lucideCircleX })],
+	template: `<div class="page-padding oeb">
+		<div class="tw-bg-lightpurple oeb-inset-padding tw-flex tw-justify-center">
+			<section
+				class="tw-border-solid tw-border-purple tw-border-2 tw-rounded-[10px] tw-bg-background tw-py-4 tw-px-16 tw-my-16 tw-inline-block tw-text-center"
+			>
+				<ng-icon hlm size="2xl" name="lucideCircleX" class="tw-text-purple tw-mb-2" />
+				<h1 hlmH1 class="tw-text-oebblack tw-text-md tw-font-semibold tw-max-w-[30ch]">
+					{{ 'BadgeCollection.collectionNotPublic' | translate }}
+				</h1>
+			</section>
+		</div>
+	</div>`,
+})
+export class PublicNotFoundBadgeCollectionComponent {}

--- a/src/app/public/public.module.ts
+++ b/src/app/public/public.module.ts
@@ -24,6 +24,7 @@ import { BadgeRequestApiService } from '../issuer/services/badgerequest-api.serv
 import { PdfDownloadComponent } from './components/pdf-download/pdf-download.component';
 import { PublicLearningPathComponent } from './components/learningpath/learningpath.component';
 import { UserProfileApiService } from '../common/services/user-profile-api.service';
+import { PublicNotFoundBadgeCollectionComponent } from './components/not-found-badge-collection/not-found-badge-collection.component';
 
 export const routes: Routes = [
 	{
@@ -124,7 +125,13 @@ export const routes: Routes = [
 			publiclyAccessible: true,
 		} as BadgrRouteData,
 	},
-
+	{
+		path: 'collections/not-found',
+		component: PublicNotFoundBadgeCollectionComponent,
+		data: {
+			publiclyAccessible: true,
+		} as BadgrRouteData,
+	},
 	{
 		path: 'collections/:collectionShareHash',
 		component: PublicBadgeCollectionComponent,
@@ -149,6 +156,7 @@ export const routes: Routes = [
 		CommonEntityManagerModule,
 		RouterModule.forChild(routes),
 		TranslateModule,
+		PublicNotFoundBadgeCollectionComponent,
 	],
 	declarations: [
 		AboutComponent,

--- a/src/app/recipient/components/recipient-badge-collection-detail/recipient-badge-collection-detail.component.ts
+++ b/src/app/recipient/components/recipient-badge-collection-detail/recipient-badge-collection-detail.component.ts
@@ -204,6 +204,8 @@ export class RecipientBadgeCollectionDetailComponent extends BaseAuthenticatedRo
 	}
 
 	openShareDialog(collection: RecipientBadgeCollection) {
+		if (!collection.published) return;
+
 		const dialogRef = this._hlmDialogService.open(ShareDialogTemplateComponent, {
 			context: {
 				collection: collection,

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -797,7 +797,8 @@
 		"deleteText": "Bist du sicher, dass du die Sammlung {{ collectionname }} löschen möchtest?",
 		"searchBadges": "Meine Badges durchsuchen",
 		"downloadQrCode": "QR-Code herunterladen",
-		"copiedToClipboard": "In die Zwischenablage kopiert!"
+		"copiedToClipboard": "In die Zwischenablage kopiert!",
+		"collectionNotPublic": "Diese Sammlung ist momentan nicht für die Öffentlichkeit freigeschaltet."
 	},
 	"Profile": {
 		"more": "Mehr",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -797,7 +797,8 @@
 		"deleteText": "Are you sure you want to delete collection {{ collectionname }}?",
 		"searchBadges": "Search my badges",
 		"downloadQrCode": "Download QR-Code",
-		"copiedToClipboard": "Copied to clipboard!"
+		"copiedToClipboard": "Copied to clipboard!",
+		"collectionNotPublic": "This collection is currently not available to the public."
 	},
 	"Profile": {
 		"more": "More",


### PR DESCRIPTION
This PR does introduces the following changes:
- Prevent the sharing dialog of collections from being opened when the collection is private (found this bug during testing)
- Following the changes introduced in mint-o-badges/badgr-server#449
  - Introduce a `/public/collections/not-found` route that the server may redirect to when a private collection is requested
  - Handle http status code 204 when the ui requests a collection json -> show contents of not found route