### PR TITLE
fix: prevent submit of oeb-input only when erroneous

### DIFF
--- a/src/app/components/input.component.ts
+++ b/src/app/components/input.component.ts
@@ -172,7 +172,8 @@ export class OebInputComponent {
 		if (event.code === 'Enter') {
 			this.control.markAsDirty();
 			this.cacheControlState();
-			event.preventDefault();
+
+			if (this.cachedErrorState) event.preventDefault();
 		}
 		// If fieldType is number prevent strings and chars from entering
 		if (this.fieldType === 'number') {


### PR DESCRIPTION
This PR only prevents an `oeb-input`s default action in case one presses enter, when the input is actually erroneous.
I am not 100% certain that this doesn't break existing "features" even though the existing comment is clearly speaking of a hack.

This does work with the login perfectly fine though.

Fixes #1141