### PR TITLE
build(ci): run actions for prs added to merge queue

### DIFF
--- a/.github/workflows/registry-build-publish.yml
+++ b/.github/workflows/registry-build-publish.yml
@@ -8,6 +8,10 @@ on:
         branches:
             - main
             - develop
+    merge_group:
+        branches:
+            - production
+            - main
 
 env:
     REGISTRY: ghcr.io


### PR DESCRIPTION
This (hopefully) finally fixes the problem with checks blocking the merge queue.