### PR TITLE
fix: loading badges when issuer set

### DIFF
--- a/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
+++ b/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
@@ -234,8 +234,9 @@ export class LearningPathEditFormComponent
 		if (!this.issuer)
 			this.issuerManager.issuerBySlug(this.issuerSlug).then((issuer) => {
 				this.issuer = issuer;
+				this.badgesLoaded = this.loadBadges();
 			});
-		this.badgesLoaded = this.loadBadges();
+		else this.badgesLoaded = this.loadBadges();
 	}
 	next: string;
 	previous: string;


### PR DESCRIPTION
Follow-up to #1693 where the loading of badges needs to be postponed until the issuer is loaded.