### PR TITLE
fix: prevent public assertion pages from trying to calculate lp progress

### DIFF
--- a/src/app/common/components/badge-detail/badge-detail.component.ts
+++ b/src/app/common/components/badge-detail/badge-detail.component.ts
@@ -29,6 +29,8 @@ import {
 	ShareBadgeDialogComponent,
 	ShareBadgeDialogContext,
 } from '~/common/dialogs/oeb-dialogs/share-badge-dialog.component';
+import { AUTH_PROVIDER } from '~/common/services/authentication-service';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
 	selector: 'bg-badgedetail',
@@ -58,6 +60,7 @@ import {
 	],
 })
 export class BgBadgeDetail {
+	private authService = inject(AUTH_PROVIDER);
 	private dialogService = inject(HlmDialogService);
 	private translate = inject(TranslateService);
 	private recipientManager = inject(RecipientBadgeManager);
@@ -65,6 +68,8 @@ export class BgBadgeDetail {
 	@Input() config: PageConfig;
 	@Input() awaitPromises?: Promise<any>[];
 	@Input() badge?: RecipientBadgeInstance | BadgeInstance | ApiImportedBadgeInstance;
+
+	isLoggedIn = toSignal(this.authService.isLoggedIn$);
 
 	constructor() {
 		this.translate.get('Badge.categories.competency').subscribe((str) => {
@@ -97,6 +102,7 @@ export class BgBadgeDetail {
 	}
 
 	checkCompleted(lp: LearningPath | PublicApiLearningPath): boolean {
+		if (!this.isLoggedIn()) return false;
 		if (lp.required_badges_count != lp.badges.length) {
 			const userAssertions = this.recipientManager.recipientBadgeList.entities;
 			const badgeClassIds = lp.badges.map((b) => b.badge.slug);


### PR DESCRIPTION
When not logged in, accessing `this.recipientManager.recipientBadges.entities` would try to fetch entities from the backend without being authenticated.
The result is a 401 which in turn tries to invalidate a non existing token leading to a refresh of the page, starting the process all over again.

This PR simply adds a logged in check to the relevant method.