### PR TITLE
fix: add missing fields to public api badgeclass

### DIFF
--- a/src/app/public/components/badgeclass/badgeclass.component.ts
+++ b/src/app/public/components/badgeclass/badgeclass.component.ts
@@ -123,8 +123,8 @@ export class PublicBadgeClassComponent implements OnInit {
 					networkBadge: badge.isNetworkBadge,
 					networkImage: badge.networkImage,
 					networkName: badge.networkName,
-					courseUrl: badge.badgeClass.courseUrl,
-					expiration: badge.badgeClass.expiration,
+					courseUrl: badge.courseUrl,
+					expiration: badge.expiration,
 				};
 
 				// wait for user profile, emails, issuer to check if user can copy

--- a/src/app/public/models/public-api.model.ts
+++ b/src/app/public/models/public-api.model.ts
@@ -153,6 +153,7 @@ export interface PublicApiBadgeClass {
 	// Extension to the spec containing the original URL of this assertion if it is not stored by Badgr
 	sourceUrl?: string;
 	courseUrl?: string;
+	expiration?: number;
 	badge?: any;
 	copy_permissions?: BadgeClassCopyPermissions[];
 	awardCriteria?: Array<{ name: string; description: string }>;


### PR DESCRIPTION
This PR fixes the currently broken public badge class page (when not logged in) due to missing or rather incorrectly accessed properties.

@strautvetter This is the one you notified me about, please have a look and merge at your convenience :-)