### PR TITLE
add badge field "area" #1879

### DIFF
--- a/src/app/catalog/catalog.service.ts
+++ b/src/app/catalog/catalog.service.ts
@@ -60,12 +60,38 @@ export class CatalogService extends BaseHttpApiService {
 	}
 
 	/**
+	 * Gets a list of areas for a given entity type
+	 * @param entityType The type of entity to get areas for (so far only implemented for 'badges')
+	 * @returns An array of available areas
+	 */
+	private async getEntityAreas(entityType: 'badges'): Promise<string[]> {
+		try {
+			const response = await this.get<string[]>(`${this.baseUrl}/${ENDPOINT}/${entityType}/areas`);
+
+			if (response.ok) return response.body;
+			else {
+				console.warn(
+					`Request for ${entityType} areas did not return ok, got ${response.status}: ${response.statusText}`,
+				);
+				return [];
+			}
+		} catch (e) {
+			console.warn(e);
+			return [];
+		}
+	}
+
+	/**
 	 * Gets a list of tags, whose entries may be used as input for
 	 * the tags parameter of the {@link getBadges} method
 	 * @returns An array of available tags to filter badges by
 	 */
 	async getBadgeTags(): Promise<string[]> {
 		return this.getEntityTags('badges');
+	}
+
+	async getBadgeAreas(): Promise<string[]> {
+		return this.getEntityAreas('badges');
 	}
 
 	/**

--- a/src/app/common/components/badge-detail/badge-detail.component.html
+++ b/src/app/common/components/badge-detail/badge-detail.component.html
@@ -312,6 +312,16 @@
 											</dd>
 										</div>
 									}
+									@if (config.areas?.length > 0) {
+										<div class="tw-flex tw-text-sm tw-mt-1 tw-pt-1 md:tw-flex-row tw-flex-col">
+											<dt class="tw-text-darkgray">
+												{{ 'RecBadgeDetail.area' | translate }}
+											</dt>
+											<dd class="tw-text-oebblack tw-font-medium md:tw-ml-2">
+										      {{ config.areas.join(', ') }}
+											</dd>
+										</div>
+									}
 									@if (config.activity_start_date) {
 										<dt class="tw-text-sm tw-text-darkgray tw-mt-1 tw-pt-1">
 											{{ 'RecBadge.courseDateShort' | translate }}

--- a/src/app/common/components/badge-detail/badge-detail.component.types.ts
+++ b/src/app/common/components/badge-detail/badge-detail.component.types.ts
@@ -80,6 +80,7 @@ export interface PageConfig {
 	activity_city?: string;
 	category: string;
 	tags: string[];
+	areas: string[];
 	issuerName: string;
 	issuerImagePlacholderUrl: string;
 	issuerImage: string;

--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
@@ -474,6 +474,7 @@ export class BadgeClassDetailComponent
 			duration: badgeClass.extension['extensions:StudyLoadExtension'].StudyLoad,
 			category: badgeClass.extension['extensions:CategoryExtension']?.Category,
 			tags: badgeClass.tags,
+			areas: badgeClass.areas,
 			issuerName: badgeClass.issuerName,
 			issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 			issuerImage: this.issuer.image,

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -941,17 +941,20 @@
 					</cdk-step>
 				}
 
-				<cdk-step label="Tags" [optional]="true" errorMessage="Bitte Tags auswählen">
+				<cdk-step
+					label="{{'CreateBadge.tagsAndAreaStep' | translate}}"
+					[optional]="true"
+				>
 					<div class="section tw-text-oebblack tw-mt-6">
 						<div>
 							@if (badgeCategory !== 'competency' || existingBadgeClass) {
 								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
+									{{ selectedStep + 1 + 'a.' }} {{ 'CreateBadge.addTags' | translate }}
 								</h2>
 							}
 							@if (badgeCategory === 'competency' && !existingBadgeClass) {
 								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
+									{{ selectedStep + 1 + 'a.' }} {{ 'CreateBadge.addTags' | translate }}
 								</h2>
 							}
 						</div>
@@ -1008,6 +1011,81 @@
 												(click)="removeTag(tag)"
 												icon="lucideCircleX"
 												text="{{ tag }}"
+											>
+											</oeb-button>
+										</div>
+									}
+								</div>
+							}
+						</div>
+					</div>
+
+					<div class="section tw-text-oebblack tw-mt-6">
+						<div>
+							@if (badgeCategory !== 'competency' || existingBadgeClass) {
+								<h2 hlmH2 class="tw-font-bold">
+									{{ selectedStep + 1 + 'b.' }} {{ 'CreateBadge.addAreas' | translate }}
+								</h2>
+							}
+							@if (badgeCategory === 'competency' && !existingBadgeClass) {
+								<h2 hlmH2 class="tw-font-bold">
+									{{ selectedStep + 1 + 'b.' }} {{ 'CreateBadge.addAreas' | translate }}
+								</h2>
+							}
+						</div>
+						<p
+							class="tw-italic tw-text-purple tw-mt-2"
+							[translate]="'CreateBadge.areaInfo'"
+							[translateParams]="{ items: 'Badges', items2: 'Badges' }"
+						></p>
+						<div class="formsection-x-body tw-mt-4">
+							<div class="tw-flex tw-gap-4 tw-items-center tw-mb-2">
+								<span class="tw-font-semibold tw-text-lg tw-text-oebblack tw-uppercase"> Area</span>
+
+								<div class="ng-autocomplete">
+									<ng-autocomplete
+										name="addarea"
+										id="addarea"
+										#newAreaInput
+										[data]="existingAreas"
+										maxlength="50"
+										[isLoading]="existingAreasLoading"
+										searchKeyword="name"
+										[placeholder]="newArea"
+										(keypress)="handleAreaInputKeyPress($event)"
+										[itemTemplate]="itemTemplate"
+										[notFoundTemplate]="notFoundAreaTemplate"
+									>
+									</ng-autocomplete>
+
+									<ng-template #itemTemplate let-item>
+										<a [innerHTML]="item.name"></a>
+									</ng-template>
+
+									<ng-template #notFoundAreaTemplate let-notFound>
+										<div>{{ 'CreateBadge.areaDoesNotExist' | translate }}</div>
+									</ng-template>
+								</div>
+
+								<oeb-button
+									[id]="'add-area-btn'"
+									size="sm"
+									type="button"
+									(click)="addArea()"
+									text="{{ 'General.add' | translate }}"
+								>
+								</oeb-button>
+							</div>
+							@if (areas.size > 0) {
+								<div class="tw-flex tw-flex-wrap tw-gap-4 tw-w-[70%] tw-ml-[3.2rem]">
+									@for (area of areas; track area) {
+										<div class="tw-flex tw-items-center tw-rounded-full tw-py-1 tw-mb-2">
+											<oeb-button
+												variant="secondary"
+												size="xxs"
+												(click)="removeArea(area)"
+												icon="lucideCircleX"
+												text="{{ area }}"
 											>
 											</oeb-button>
 										</div>

--- a/src/app/issuer/models/badgeclass-api.model.ts
+++ b/src/app/issuer/models/badgeclass-api.model.ts
@@ -35,6 +35,7 @@ export interface ApiBadgeClassForCreation {
 	extensions?: object;
 
 	tags?: string[];
+	areas?: string[];
 	alignment?: ApiBadgeClassAlignment[];
 	expiration?: number; // in days
 	copy_permissions?: BadgeClassCopyPermissions[];

--- a/src/app/issuer/models/badgeclass.model.ts
+++ b/src/app/issuer/models/badgeclass.model.ts
@@ -111,6 +111,13 @@ export class BadgeClass extends ManagedEntity<ApiBadgeClass, BadgeClassRef> {
 		this.apiModel.tags = tags;
 	}
 
+	get areas(): string[] {
+		return this.apiModel.areas;
+	}
+	set areas(areas: string[]) {
+		this.apiModel.areas = areas;
+	}
+
 	get extension() {
 		return this.apiModel.extensions;
 	}

--- a/src/app/public/components/badge-assertion/badge-assertion.component.ts
+++ b/src/app/public/components/badge-assertion/badge-assertion.component.ts
@@ -259,6 +259,7 @@ export class PublicBadgeAssertionComponent {
 					slug: assertion.badge.id,
 					category: assertion.badge['extensions:CategoryExtension'].Category,
 					tags: assertion.badge.tags,
+					areas: assertion.badge.areas,
 					issuerName: assertion.badge.issuer.name,
 					issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 					issuerImage: assertion.badge.issuer.image,

--- a/src/app/public/components/badgeclass/badgeclass.component.ts
+++ b/src/app/public/components/badgeclass/badgeclass.component.ts
@@ -109,6 +109,7 @@ export class PublicBadgeClassComponent implements OnInit {
 					category: badge['extensions:CategoryExtension']?.Category,
 					duration: badge['extensions:StudyLoadExtension'].StudyLoad,
 					tags: badge.tags,
+					areas: badge.areas,
 					issuerName: badge.issuer.name,
 					issuerImagePlacholderUrl: this.issuerImagePlaceholderUrl,
 					issuerImage: badge.issuer.image,

--- a/src/app/public/models/public-api.model.ts
+++ b/src/app/public/models/public-api.model.ts
@@ -150,6 +150,7 @@ export interface PublicApiBadgeClass {
 		targetCode?: string;
 	}>;
 	tags: string[];
+	areas: string[];
 	// Extension to the spec containing the original URL of this assertion if it is not stored by Badgr
 	sourceUrl?: string;
 	courseUrl?: string;

--- a/src/app/recipient/components/imported-badge-detail/imported-badge-detail.component.ts
+++ b/src/app/recipient/components/imported-badge-detail/imported-badge-detail.component.ts
@@ -154,6 +154,7 @@ export class ImportedBadgeDetailComponent extends BaseAuthenticatedRoutableCompo
 						)
 					: null,
 				tags: [],
+				areas: [],
 				issuerName: this.badge.json.badge.issuer.name,
 				issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 				issuerImage: this.badge.json.badge.issuer.image,

--- a/src/app/recipient/components/recipient-earned-badge-detail/recipient-earned-badge-detail.component.ts
+++ b/src/app/recipient/components/recipient-earned-badge-detail/recipient-earned-badge-detail.component.ts
@@ -166,6 +166,7 @@ export class RecipientEarnedBadgeDetailComponent extends BaseAuthenticatedRoutab
 							? 'Online'
 							: null,
 					tags: this.badge.badgeClass.tags,
+					areas: this.badge.badgeClass.areas,
 					issuerName: this.badge.badgeClass.issuer.name,
 					issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 					issuerImage: this.badge.badgeClass?.issuer?.image,

--- a/src/app/recipient/models/recipient-badge-api.model.ts
+++ b/src/app/recipient/models/recipient-badge-api.model.ts
@@ -83,6 +83,7 @@ export interface ApiRecipientBadgeClass {
 	criteria_text?: string;
 	criteria_url?: string;
 	tags: string[];
+	areas: string[];
 	issuer: ApiRecipientBadgeIssuer;
 	slug?: string;
 }

--- a/src/app/recipient/services/recipient-badges-api.service.ts
+++ b/src/app/recipient/services/recipient-badges-api.service.ts
@@ -131,6 +131,7 @@ export class RecipientBadgeApiService extends BaseHttpApiService {
 						email: importedBadge.json.badge.issuer.email,
 					},
 					tags: [],
+					areas: [],
 					slug: '',
 					alignment: [],
 				},

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -636,10 +636,15 @@
 		"durationPositive": "Bitte gib eine positive Zahl oder 0 ein",
 		"valuePositive": "Bitte gib eine positive Zahl ein",
 		"optionalBadgeDetails": "Optionale Badge-Details",
+		"tagsAndAreaStep": "Tags and Bereiche",
 		"addTags": "Tags hinzufügen",
 		"newTag": "Einen Tag eingeben...",
 		"tagDoesNotExist": "Dieser Tag existiert noch nicht",
 		"tagInfo": "Tags verschlagworten {{items}} und helfen Lernenden auf OEB bei der Suche von {{items2}} zu bestimmten Themen.",
+		"addAreas": "Bereiche hinzufügen",
+		"newArea": "Einen Bereich eingeben...",
+		"areaDoesNotExist": "Dieser Bereich existiert noch nicht",
+		"areaInfo": "Bereiche helfen Lernenden {{items}} zu kategorisieren.",
 		"removeAlignment": "Verknpüfung entfernen",
 		"removeAlignmentInfo": "Bist du sicher, dass du die Verknpüfung(en) entfernen möchtest? ",
 		"irreversibleAction": "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -936,7 +941,8 @@
 		"pdfDownload": "PDF-Zertifikat herunterladen",
 		"downloadMicroDegree": "Micro Degree herunterladen",
 		"place": "Ort",
-		"expiryAfter": "Gültigkeit ab Vergabe"
+		"expiryAfter": "Gültigkeit ab Vergabe",
+		"area": "Bereiche"
 	},
 	"BadgeCollection": {
 		"addCollection": "Sammlung hinzufügen",
@@ -1148,6 +1154,7 @@
 		"dragDropInfo": "Mittels <span class='tw-font-bold'>Drag & Drop</span> kannst du deine ausgewählten Badges hier in die Reihenfolge bringen, in der sie innerhalb des Lernpfads angezeigt werden sollen.",
 		"lpDerivedData": "Folgende Daten haben wir übernommen:",
 		"addTag": "Tag hinzufügen",
+		"addArea": "Bereich hinzufügen",
 		"createdSuccessfully": "Dein Lernpfad wurde erfolgreich erstellt.",
 		"savedSuccessfully": "Deine Änderungen wurden erfolgreich gespeichert",
 		"title": "Lernpfad-Titel",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -637,10 +637,15 @@
 		"durationPositive": "Please enter a positive number or 0",
 		"valuePositive": "Please enter a positive number",
 		"optionalBadgeDetails": "Optional badge details",
+		"tagsAndAreaStep": "Tags and areas",
 		"addTags": "Add tags",
 		"newTag": "Enter a tag...",
 		"tagDoesNotExist": "This tag does not exist yet",
 		"tagInfo": "Tags help categorize {{items}} and help learners on OEB search for {{items2}} on specific topics.",
+		"addAreas": "Add areas",
+		"newArea": "Enter an area...",
+		"areaDoesNotExist": "This area does not exist yet",
+		"areaInfo": "Areas help learners to categorize their {{items}}.",
 		"removeAlignment": "Remove link",
 		"removeAlignmentInfo": "Are you sure you want to remove the link(s)? ",
 		"irreversibleAction": "This action cannot be undone.",
@@ -937,7 +942,8 @@
 		"downloadMicroDegree": "Download Micro Degree",
 		"pdfDownload": "Download PDF-Certificate",
 		"place": "Place",
-		"expiryAfter": "Validity from Date of Award"
+		"expiryAfter": "Validity from Date of Award",
+		"area": "Areas"
 	},
 	"BadgeCollection": {
 		"addCollection": "Add collection",
@@ -1149,6 +1155,7 @@
 		"dragDropInfo": "You can use <span class='tw-font-bold'>drag & drop</span> to arrange your selected badges here in the order they should appear within the learning path.",
 		"lpDerivedData": "We have adopted the following data:",
 		"addTag": "Add tag",
+		"addArea": "Add area",
 		"createdSuccessfully": "Your learning path has been created successfully.",
 		"savedSuccessfully": "Your changes have been saved successfully",
 		"title": "Learning path title",


### PR DESCRIPTION
This PR adds an optional “Area” field to badges, allowing users to assign one or more areas. The behavior mirrors the existing tag functionality, including free-text input, autocomplete suggestions, and reusable terms. Assigned areas are stored with the badge and shown on the badge detail page.

Changes:
- Added “Area” field under Tags in badge create/edit
- Free-text input with autocomplete after three characters
- Dropdown suggestions based on existing areas
- New areas created automatically on save
- Areas persisted with the badge and displayed in the detail sidebar