### PR TITLE
fix: enable network btn when owner or creator

### DIFF
--- a/src/app/issuer/components/network-dashboard/network-dashboard.component.html
+++ b/src/app/issuer/components/network-dashboard/network-dashboard.component.html
@@ -91,7 +91,10 @@
 					[variant]="partnerIssuers().length ? 'secondary' : 'default'"
 					(click)="openDialog()"
 					[text]="'Network.inviteInstitutions' | translate"
-					[disabled]="network().current_user_network_role !== 'owner'"
+					[disabled]="
+						network().current_user_network_role !== 'owner' &&
+						network().current_user_network_role !== 'creator'
+					"
 				>
 				</oeb-button>
 			</div>


### PR DESCRIPTION
cherry pick fix from open-educational-badges/badgr-ui#1876 (already on develop)