### PR TITLE
fix: remove not working breadcrumbs and cancel button in badge create… (#1941)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -112,7 +112,8 @@
 								"src/styles/google-webfonts/nunito.scss",
 								"src/styles/google-webfonts/rubik.scss",
 								"src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.css",
-								"src/app/issuer/components/badgeclass-select-type/badgeclass-select-type.component.scss"
+								"src/app/issuer/components/badgeclass-select-type/badgeclass-select-type.component.scss",
+								"src/app/issuer/components/badgeclass-edit-form/oeb-badgeclass-edit-form.component.css"
 							],
 							"assets": [
 								"src/favicon.ico",

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -1,4 +1,10 @@
-<div class="oeb">
+<div
+	class="{{
+		!existingBadgeClass && !initialisedBadgeClass
+			? 'oeb create'
+			: 'oeb edit'
+	}}"
+>
 	<form-message></form-message>
 	@if (showLegend) {
 		<app-badge-legend (closed)="closeLegend()"></app-badge-legend>

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -1,10 +1,4 @@
-<div
-	class="{{
-		!existingBadgeClass && !initialisedBadgeClass
-			? 'oeb create'
-			: 'oeb edit'
-	}}"
->
+<div class="{{ !existingBadgeClass && !initialisedBadgeClass ? 'oeb create' : 'oeb edit' }}">
 	<form-message></form-message>
 	@if (showLegend) {
 		<app-badge-legend (closed)="closeLegend()"></app-badge-legend>

--- a/src/app/issuer/components/badgeclass-edit-form/oeb-badgeclass-edit-form.component.css
+++ b/src/app/issuer/components/badgeclass-edit-form/oeb-badgeclass-edit-form.component.css
@@ -1,0 +1,7 @@
+.oeb-breadcrumbs {
+	display: none;
+}
+
+badgeclass-edit-form > .edit form > div > oeb-button:first-child {
+	display: none;
+}

--- a/src/app/issuer/components/badgeclass-edit-form/oeb-badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/oeb-badgeclass-edit-form.component.ts
@@ -192,6 +192,7 @@ import { BadgeClassApiService } from '~/issuer/services/badgeclass-api.service';
 			</div>
 		}
 	`,
+	styleUrl: './oeb-badgeclass-edit-form.component.css',
 	imports: [
 		BadgeClassEditFormComponent,
 		AsyncPipe,


### PR DESCRIPTION
#1941

In the badge create / edit iframe the breadcrumb and the cancel button on edit did not work.
This commit sets both elements to display none.

