### PR TITLE
feat(badgeclass): add Areas input and display

### DIFF
--- a/src/app/catalog/catalog.service.ts
+++ b/src/app/catalog/catalog.service.ts
@@ -79,6 +79,27 @@ export class CatalogService extends BaseHttpApiService {
 	}
 
 	/**
+	 * Gets a list of areas for badges
+	 * @returns An array of available areas to filter badges by
+	 */
+	async getBadgeAreas(): Promise<string[]> {
+		try {
+			const response = await this.get<string[]>(`${this.baseUrl}/${ENDPOINT}/badges/areas`);
+
+			if (response.ok) return response.body;
+			else {
+				console.warn(
+					`Request for badge areas did not return ok, got ${response.status}: ${response.statusText}`,
+				);
+				return [];
+			}
+		} catch (e) {
+			console.warn(e);
+			return [];
+		}
+	}
+
+	/**
 	 * Gets a paginated list of badges, optionally filtered by name and/or tags.
 	 * Offset-based pagination is used, so pagination is achieved by setting the limit and offset
 	 * by multiples of the limit to go through pages (e.g. limit = 3, offset = 6 results in a request

--- a/src/app/common/components/badge-detail/badge-detail.component.html
+++ b/src/app/common/components/badge-detail/badge-detail.component.html
@@ -317,6 +317,16 @@
 											</dd>
 										</div>
 									}
+									@if (config.areas && config.areas.length > 0) {
+										<div class="tw-flex tw-text-sm tw-mt-1 tw-pt-1 md:tw-flex-row tw-flex-col">
+											<dt class="tw-text-darkgray">
+												{{ 'BadgeDetail.areas' | translate }}
+											</dt>
+											<dd class="tw-text-oebblack tw-font-medium md:tw-ml-2">
+												{{ config.areas.join(', ') }}
+											</dd>
+										</div>
+									}
 									@if (config.activity_start_date) {
 										<dt class="tw-text-sm tw-text-darkgray tw-mt-1 tw-pt-1">
 											{{ 'RecBadge.courseDateShort' | translate }}

--- a/src/app/common/components/badge-detail/badge-detail.component.types.ts
+++ b/src/app/common/components/badge-detail/badge-detail.component.types.ts
@@ -80,6 +80,7 @@ export interface PageConfig {
 	activity_city?: string;
 	category: string;
 	tags: string[];
+	areas?: string[];
 	issuerName: string;
 	issuerImagePlacholderUrl: string;
 	issuerImage: string;

--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
@@ -475,6 +475,7 @@ export class BadgeClassDetailComponent
 			duration: badgeClass.extension['extensions:StudyLoadExtension'].StudyLoad,
 			category: badgeClass.extension['extensions:CategoryExtension']?.Category,
 			tags: badgeClass.tags,
+			areas: badgeClass.areas,
 			issuerName: badgeClass.issuerName,
 			issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 			issuerImage: this.issuer.image,

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -938,20 +938,12 @@
 					</cdk-step>
 				}
 
-				<cdk-step label="Tags" [optional]="true" errorMessage="Bitte Tags auswählen">
+				<cdk-step [label]="'CreateBadge.tagsAndAreas' | translate" [optional]="true" errorMessage="Bitte Tags auswählen">
+					<!-- Tags Section -->
 					<div class="section tw-text-oebblack tw-mt-6">
-						<div>
-							@if (badgeCategory !== 'competency' || existingBadgeClass) {
-								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
-								</h2>
-							}
-							@if (badgeCategory === 'competency' && !existingBadgeClass) {
-								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
-								</h2>
-							}
-						</div>
+						<h2 hlmH2 class="tw-font-bold">
+							{{ 'CreateBadge.addTags' | translate }}
+						</h2>
 						<p
 							class="tw-italic tw-text-purple tw-mt-2"
 							[translate]="'CreateBadge.tagInfo'"
@@ -1005,6 +997,73 @@
 												(click)="removeTag(tag)"
 												icon="lucideCircleX"
 												text="{{ tag }}"
+											>
+											</oeb-button>
+										</div>
+									}
+								</div>
+							}
+						</div>
+					</div>
+
+					<!-- Areas Section -->
+					<div class="section tw-text-oebblack tw-mt-6">
+						<h2 hlmH2 class="tw-font-bold">
+							{{ 'CreateBadge.addAreas' | translate }}
+						</h2>
+						<p
+							class="tw-italic tw-text-purple tw-mt-2"
+							[translate]="'CreateBadge.areaInfo'"
+							[translateParams]="{ items: 'Badges', items2: 'Badges' }"
+						></p>
+						<div class="formsection-x-body tw-mt-4">
+							<div class="tw-flex tw-gap-4 tw-items-center tw-mb-2">
+								<span class="tw-font-semibold tw-text-lg tw-text-oebblack tw-uppercase">{{ 'General.area' | translate }}</span>
+
+								<div class="ng-autocomplete">
+									<ng-autocomplete
+										name="addarea"
+										id="addarea"
+										#newAreaInput
+										[data]="existingAreas"
+										maxlength="50"
+										[isLoading]="existingAreasLoading"
+										searchKeyword="name"
+										[placeholder]="newArea"
+										(keypress)="handleAreaInputKeyPress($event)"
+										[itemTemplate]="areaItemTemplate"
+										[notFoundTemplate]="areaNotFoundTemplate"
+									>
+									</ng-autocomplete>
+
+									<ng-template #areaItemTemplate let-item>
+										<a [innerHTML]="item.name"></a>
+									</ng-template>
+
+									<ng-template #areaNotFoundTemplate let-notFound>
+										<div>{{ 'CreateBadge.areaDoesNotExist' | translate }}</div>
+									</ng-template>
+								</div>
+
+								<oeb-button
+									[id]="'add-area-btn'"
+									size="sm"
+									type="button"
+									(click)="addArea()"
+									text="{{ 'General.add' | translate }}"
+								>
+								</oeb-button>
+							</div>
+							@if (areas.size > 0) {
+								<div class="tw-flex tw-flex-wrap tw-gap-4 tw-w-[70%] tw-ml-[3.2rem]">
+									@for (area of areas; track area) {
+										<div class="tw-flex tw-items-center tw-rounded-full tw-py-1 tw-mb-2">
+											<oeb-button
+												variant="secondary"
+												size="xxs"
+												(click)="removeArea(area)"
+												icon="lucideCircleX"
+												text="{{ area }}"
 											>
 											</oeb-button>
 										</div>

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -172,6 +172,7 @@ export class BadgeClassEditFormComponent
 
 	chooseDuration = this.translate.instant('CreateBadge.chooseDuration');
 	newTag = this.translate.instant('CreateBadge.newTag');
+	newArea = this.translate.instant('CreateBadge.newArea');
 
 	suggestCompetenciesText = this.translate.instant('CreateBadge.suggestCompetencies');
 
@@ -455,6 +456,9 @@ export class BadgeClassEditFormComponent
 	@ViewChild('newTagInput')
 	newTagInput: ElementRef<HTMLInputElement>;
 
+	@ViewChild('newAreaInput')
+	newAreaInput: ElementRef<HTMLInputElement>;
+
 	@ViewChild('formElem')
 	formElem: ElementRef<HTMLFormElement>;
 
@@ -494,6 +498,20 @@ export class BadgeClassEditFormComponent
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Tags
 	tags = new Set<string>();
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Areas
+	areas = new Set<string>();
+
+	/**
+	 * Indicates whether the existing areas are currently being loaded.
+	 */
+	existingAreasLoading: boolean;
+
+	/**
+	 * The already existing areas for other badges, for the autocomplete to show.
+	 */
+	existingAreas: { id: number; name: string }[];
 
 	collapsedCompetenciesOpen = false;
 
@@ -658,12 +676,18 @@ export class BadgeClassEditFormComponent
 		this.tags = new Set();
 		this.badgeClass.tags.forEach((t) => this.tags.add(t));
 
+		this.areas = new Set();
+		if (this.badgeClass.areas) {
+			this.badgeClass.areas.forEach((a) => this.areas.add(a));
+		}
+
 		this.alignmentsEnabled = this.badgeClass.alignments.length > 0;
 	}
 
 	ngOnInit() {
 		super.ngOnInit();
 		this.fetchTags();
+		this.fetchAreas();
 
 		this.durationOptions = getDurationOptions(this.translate);
 
@@ -1010,6 +1034,50 @@ export class BadgeClassEditFormComponent
 
 	removeTag(tag: string) {
 		this.tags.delete(tag);
+	}
+
+	/**
+	 * Fetches the areas from the catalogService.
+	 * The areas are then assigned to existingAreas in an appropriate format.
+	 */
+	fetchAreas() {
+		this.existingAreas = [];
+		this.existingAreasLoading = true;
+		this.catalogService.getBadgeAreas().then(
+			(areas) => {
+				this.existingAreas = areas.map((area, index) => ({
+					id: index,
+					name: area,
+				}));
+				this.existingAreasLoading = false;
+			},
+			(err) => {
+				console.error("Couldn't fetch areas: " + err);
+				this.existingAreasLoading = false;
+			},
+		);
+	}
+
+	addArea() {
+		const newArea = (this.newAreaInput['query'] || '').trim().toLowerCase();
+
+		if (newArea.length > 0) {
+			this.areas.add(newArea);
+
+			this.newAreaInput['query'] = '';
+		}
+	}
+
+	handleAreaInputKeyPress(event: KeyboardEvent) {
+		if (event.keyCode === 13 /* Enter */) {
+			this.addArea();
+			this.newAreaInput.nativeElement.focus();
+			event.preventDefault();
+		}
+	}
+
+	removeArea(area: string) {
+		this.areas.delete(area);
 	}
 
 	enableAlignments() {
@@ -1448,6 +1516,7 @@ export class BadgeClassEditFormComponent
 				this.existingBadgeClass.imageFrame = imageFrame;
 				this.existingBadgeClass.alignments = this.alignmentsEnabled ? formState.alignments : [];
 				this.existingBadgeClass.tags = Array.from(this.tags);
+				this.existingBadgeClass.areas = Array.from(this.areas);
 				this.existingBadgeClass.courseUrl = formState.courseUrl;
 				this.existingBadgeClass.criteria = await this.getCriteriaAsBadgeLanguage(
 					formState.criteria,
@@ -1508,6 +1577,7 @@ export class BadgeClassEditFormComponent
 					image: !imageFrame ? formState.badge_image : null,
 					imageFrame: imageFrame,
 					tags: Array.from(this.tags),
+					areas: Array.from(this.areas),
 					alignment: this.alignmentsEnabled ? formState.alignments : [],
 					expiration: expirationDays,
 					criteria: await this.getCriteriaAsBadgeLanguage(formState.criteria, formState.badge_language),

--- a/src/app/issuer/models/badgeclass-api.model.ts
+++ b/src/app/issuer/models/badgeclass-api.model.ts
@@ -36,6 +36,7 @@ export interface ApiBadgeClassForCreation {
 	extensions?: object;
 
 	tags?: string[];
+	areas?: string[];
 	alignment?: ApiBadgeClassAlignment[];
 	expiration?: number; // in days
 	copy_permissions?: BadgeClassCopyPermissions[];

--- a/src/app/issuer/models/badgeclass.model.ts
+++ b/src/app/issuer/models/badgeclass.model.ts
@@ -119,6 +119,13 @@ export class BadgeClass extends ManagedEntity<ApiBadgeClass, BadgeClassRef> {
 		this.apiModel.tags = tags;
 	}
 
+	get areas(): string[] {
+		return this.apiModel.areas || [];
+	}
+	set areas(areas: string[]) {
+		this.apiModel.areas = areas;
+	}
+
 	get extension() {
 		return this.apiModel.extensions;
 	}

--- a/src/app/recipient/components/recipient-earned-badge-detail/recipient-earned-badge-detail.component.ts
+++ b/src/app/recipient/components/recipient-earned-badge-detail/recipient-earned-badge-detail.component.ts
@@ -166,6 +166,7 @@ export class RecipientEarnedBadgeDetailComponent extends BaseAuthenticatedRoutab
 							? 'Online'
 							: null,
 					tags: this.badge.badgeClass.tags,
+					areas: this.badge.badgeClass.areas,
 					issuerName: this.badge.badgeClass.issuer.name,
 					issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 					issuerImage: this.badge.badgeClass?.issuer?.image,

--- a/src/app/recipient/models/recipient-badge-api.model.ts
+++ b/src/app/recipient/models/recipient-badge-api.model.ts
@@ -83,6 +83,7 @@ export interface ApiRecipientBadgeClass {
 	criteria_text?: string;
 	criteria_url?: string;
 	tags: string[];
+	areas?: string[];
 	issuer: ApiRecipientBadgeIssuer;
 	slug?: string;
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -43,6 +43,7 @@
 		"remove": "Entfernen",
 		"add": "Hinzufügen",
 		"added": "Hinzugefügt",
+		"area": "Bereich",
 		"save": "Speichern",
 		"saveChanges": "Änderungen sichern",
 		"aboutBadges": "Badges",
@@ -646,9 +647,15 @@
 		"valuePositive": "Bitte gib eine positive Zahl ein",
 		"optionalBadgeDetails": "Optionale Badge-Details",
 		"addTags": "Tags hinzufügen",
+		"addTagsAndAreas": "Tags & Bereiche hinzufügen",
+		"tagsAndAreas": "Tags & Bereiche",
+		"addAreas": "Bereiche hinzufügen",
 		"newTag": "Einen Tag eingeben...",
 		"tagDoesNotExist": "Dieser Tag existiert noch nicht",
 		"tagInfo": "Tags verschlagworten {{items}} und helfen Lernenden auf OEB bei der Suche von {{items2}} zu bestimmten Themen.",
+		"newArea": "Einen Bereich eingeben...",
+		"areaDoesNotExist": "Dieser Bereich existiert noch nicht",
+		"areaInfo": "Bereiche kategorisieren {{items}} nach Fachgebiet und helfen Lernenden, {{items2}} in ihrem Interessengebiet zu finden.",
 		"removeAlignment": "Verknpüfung entfernen",
 		"removeAlignmentInfo": "Bist du sicher, dass du die Verknpüfung(en) entfernen möchtest? ",
 		"irreversibleAction": "Diese Aktion kann nicht rückgängig gemacht werden.",
@@ -899,6 +906,9 @@
 		"cancel": "Abbrechen",
 		"save": "Speichern",
 		"saving": "Speichere"
+	},
+	"BadgeDetail": {
+		"areas": "Bereiche"
 	},
 	"RecBadgeDetail": {
 		"shareBadge": "Badge teilen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -43,6 +43,7 @@
 		"remove": "Remove",
 		"add": "Add",
 		"added": "Added",
+		"area": "Area",
 		"save": "Save",
 		"saveChanges": "Save Changes",
 		"aboutBadges": "Badges",
@@ -647,9 +648,15 @@
 		"valuePositive": "Please enter a positive number",
 		"optionalBadgeDetails": "Optional badge details",
 		"addTags": "Add tags",
+		"addTagsAndAreas": "Add tags & areas",
+		"tagsAndAreas": "Tags & Areas",
+		"addAreas": "Add areas",
 		"newTag": "Enter a tag...",
 		"tagDoesNotExist": "This tag does not exist yet",
 		"tagInfo": "Tags help categorize {{items}} and help learners on OEB search for {{items2}} on specific topics.",
+		"newArea": "Enter an area...",
+		"areaDoesNotExist": "This area does not exist yet",
+		"areaInfo": "Areas help categorize {{items}} by subject area and help learners find {{items2}} in their field of interest.",
 		"removeAlignment": "Remove link",
 		"removeAlignmentInfo": "Are you sure you want to remove the link(s)? ",
 		"irreversibleAction": "This action cannot be undone.",
@@ -900,6 +907,9 @@
 		"cancel": "Cancel",
 		"save": "Save",
 		"saving": "Saving"
+	},
+	"BadgeDetail": {
+		"areas": "Areas"
 	},
 	"RecBadgeDetail": {
 		"shareBadge": "Share badge",


### PR DESCRIPTION
The following changes implement the frontend changes required for the feature specified in [add badge field "area"](https://github.com/open-educational-badges/badgr-ui/issues/1879). 

**Implemented:**

- Add areas field to badge API and domain models
- Add getBadgeAreas() to catalog service for autocomplete
- Add Areas autocomplete input in badge edit form (after Tags)
- Display Areas in badge detail page metadata section
- Add German and English translations for area-related strings