### PR TITLE
fix(quotas): fix saving existing badgeclass when creation quota exceeded

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -1407,7 +1407,7 @@ export class BadgeClassEditFormComponent
 				return;
 			}
 
-			if (this.issuer.quotas) {
+			if (this.issuer.quotas && !this.existingBadgeClass) {
 				// recheck quotas and show dialog if something changed while starting the creation process
 				await this.issuer.update();
 				if (!this.checkQuotasDialog('BADGE_CREATE')) {


### PR DESCRIPTION
Fixes being able to edit badgeclasses when badge creation quota limits are exceeded