### PR TITLE
feat(issuer): add badge area input field and display in badge detail 

### DIFF
--- a/src/app/catalog/catalog.service.ts
+++ b/src/app/catalog/catalog.service.ts
@@ -43,14 +43,17 @@ export class CatalogService extends BaseHttpApiService {
 	 * @param entityType The type of entity to get tags for (e.g., 'badges', 'learningpaths')
 	 * @returns An array of available tags to filter by
 	 */
-	private async getEntityTags(entityType: 'badges' | 'learningpaths'): Promise<string[]> {
+	private async getEntityMetadata(
+		entityType: 'badges' | 'learningpaths',
+		segment: 'tags' | 'areas',
+	): Promise<string[]> {
 		try {
-			const response = await this.get<string[]>(`${this.baseUrl}/${ENDPOINT}/${entityType}/tags`);
+			const response = await this.get<string[]>(`${this.baseUrl}/${ENDPOINT}/${entityType}/${segment}`);
 
 			if (response.ok) return response.body;
 			else {
 				console.warn(
-					`Request for ${entityType} tags did not return ok, got ${response.status}: ${response.statusText}`,
+					`Request for ${entityType} ${segment} did not return ok, got ${response.status}: ${response.statusText}`,
 				);
 				return [];
 			}
@@ -66,7 +69,11 @@ export class CatalogService extends BaseHttpApiService {
 	 * @returns An array of available tags to filter badges by
 	 */
 	async getBadgeTags(): Promise<string[]> {
-		return this.getEntityTags('badges');
+		return this.getEntityMetadata('badges', 'tags');
+	}
+
+	async getBadgeAreas(): Promise<string[]> {
+		return this.getEntityMetadata('badges', 'areas');
 	}
 
 	/**
@@ -75,7 +82,7 @@ export class CatalogService extends BaseHttpApiService {
 	 * @returns An array of available tags to filter learning paths by
 	 */
 	async getLearningPathTags(): Promise<string[]> {
-		return this.getEntityTags('learningpaths');
+		return this.getEntityMetadata('learningpaths', 'tags');
 	}
 
 	/**

--- a/src/app/common/components/badge-detail/badge-detail.component.html
+++ b/src/app/common/components/badge-detail/badge-detail.component.html
@@ -317,6 +317,14 @@
 											</dd>
 										</div>
 									}
+									@if (config.areas?.length > 0) {
+										<div class="tw-flex tw-text-sm tw-mt-1 tw-pt-1 md:tw-flex-row tw-flex-col">
+											<dt class="tw-text-darkgray">{{ 'Badge.area' | translate }}</dt>
+											<dd class="tw-text-oebblack tw-font-medium md:tw-ml-2">
+												{{ config.areas.join(', ') }}
+											</dd>
+										</div>
+									}
 									@if (config.activity_start_date) {
 										<dt class="tw-text-sm tw-text-darkgray tw-mt-1 tw-pt-1">
 											{{ 'RecBadge.courseDateShort' | translate }}

--- a/src/app/common/components/badge-detail/badge-detail.component.types.ts
+++ b/src/app/common/components/badge-detail/badge-detail.component.types.ts
@@ -80,6 +80,7 @@ export interface PageConfig {
 	activity_city?: string;
 	category: string;
 	tags: string[];
+	areas?: string[];
 	issuerName: string;
 	issuerImagePlacholderUrl: string;
 	issuerImage: string;

--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.ts
@@ -475,6 +475,7 @@ export class BadgeClassDetailComponent
 			duration: badgeClass.extension['extensions:StudyLoadExtension'].StudyLoad,
 			category: badgeClass.extension['extensions:CategoryExtension']?.Category,
 			tags: badgeClass.tags,
+			areas: badgeClass.areas,
 			issuerName: badgeClass.issuerName,
 			issuerImagePlacholderUrl: this.issuerImagePlacholderUrl,
 			issuerImage: this.issuer.image,

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -943,12 +943,12 @@
 						<div>
 							@if (badgeCategory !== 'competency' || existingBadgeClass) {
 								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
+									{{ 'CreateBadge.addTags' | translate }}
 								</h2>
 							}
 							@if (badgeCategory === 'competency' && !existingBadgeClass) {
 								<h2 hlmH2 class="tw-font-bold">
-									{{ selectedStep + 1 + '.' }} {{ 'CreateBadge.addTags' | translate }}
+									{{ 'CreateBadge.addTags' | translate }}
 								</h2>
 							}
 						</div>
@@ -959,7 +959,9 @@
 						></p>
 						<div class="formsection-x-body tw-mt-4">
 							<div class="tw-flex tw-gap-4 tw-items-center tw-mb-2">
-								<span class="tw-font-semibold tw-text-lg tw-text-oebblack tw-uppercase"> Tag</span>
+								<span class="tw-font-semibold tw-text-lg tw-text-oebblack tw-uppercase">{{
+									'Badge.tag' | translate
+								}}</span>
 
 								<div class="ng-autocomplete">
 									<ng-autocomplete
@@ -1011,6 +1013,66 @@
 									}
 								</div>
 							}
+							<!-- Area field inside Tags step -->
+							<div class="tw-mt-6">
+								<h2 hlmH2 class="tw-font-bold tw-mb-2">{{ 'CreateBadge.addAreas' | translate }}</h2>
+								<div class="tw-flex tw-gap-4 tw-items-center tw-mb-2">
+									<span class="tw-font-semibold tw-text-lg tw-text-oebblack tw-uppercase">{{
+										'Badge.area' | translate
+									}}</span>
+
+									<div class="ng-autocomplete">
+										<ng-autocomplete
+											name="addarea"
+											id="addarea"
+											#newAreaInput
+											[data]="existingAreas"
+											maxlength="50"
+											[isLoading]="existingAreasLoading"
+											searchKeyword="name"
+											[placeholder]="newArea"
+											[minQueryLength]="3"
+											(keypress)="handleAreaInputKeyPress($event)"
+											[itemTemplate]="areaItemTemplate"
+											[notFoundTemplate]="areaNotFoundTemplate"
+										>
+										</ng-autocomplete>
+
+										<ng-template #areaItemTemplate let-item>
+											<a [innerHTML]="item.name"></a>
+										</ng-template>
+
+										<ng-template #areaNotFoundTemplate let-notFound>
+											<div>{{ 'CreateBadge.areaDoesNotExist' | translate }}</div>
+										</ng-template>
+									</div>
+
+									<oeb-button
+										[id]="'add-area-btn'"
+										size="sm"
+										type="button"
+										(click)="addArea()"
+										text="{{ 'General.add' | translate }}"
+									>
+									</oeb-button>
+								</div>
+								@if (areas.size > 0) {
+									<div class="tw-flex tw-flex-wrap tw-gap-4 tw-w-[70%] tw-ml-[3.2rem]">
+										@for (area of areas; track area) {
+											<div class="tw-flex tw-items-center tw-rounded-full tw-py-1 tw-mb-2">
+												<oeb-button
+													variant="secondary"
+													size="xxs"
+													(click)="removeArea(area)"
+													icon="lucideCircleX"
+													text="{{ area }}"
+												>
+												</oeb-button>
+											</div>
+										}
+									</div>
+								}
+							</div>
 						</div>
 					</div>
 				</cdk-step>

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -519,6 +519,20 @@ export class BadgeClassEditFormComponent
 	};
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	// Areas
+	areas = new Set<string>();
+
+	existingAreasLoading: boolean;
+	existingAreas: { id: number; name: string }[];
+	areaOptions: FormFieldSelectOption[];
+
+	@ViewChild('newAreaInput')
+	newAreaInput: ElementRef<HTMLInputElement>;
+
+	newArea = this.translate.instant('CreateBadge.newArea');
+	areaInfo = this.translate.instant('CreateBadge.areaInfo');
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Alignments
 	alignmentsEnabled = false;
 	showAdvanced: boolean[] = [false];
@@ -658,13 +672,16 @@ export class BadgeClassEditFormComponent
 		this.tags = new Set();
 		this.badgeClass.tags.forEach((t) => this.tags.add(t));
 
+		this.areas = new Set();
+		this.badgeClass.areas.forEach((a) => this.areas.add(a));
+
 		this.alignmentsEnabled = this.badgeClass.alignments.length > 0;
 	}
 
 	ngOnInit() {
 		super.ngOnInit();
 		this.fetchTags();
-
+		this.fetchAreas();
 		this.durationOptions = getDurationOptions(this.translate);
 
 		if (this.issuer.is_network) {
@@ -1011,7 +1028,51 @@ export class BadgeClassEditFormComponent
 	removeTag(tag: string) {
 		this.tags.delete(tag);
 	}
+	fetchAreas() {
+		this.existingAreas = [];
+		this.existingAreasLoading = true;
+		this.catalogService.getBadgeAreas().then(
+			(areas) => {
+				this.existingAreas = areas.map((area, index) => ({
+					id: index,
+					name: area,
+				}));
+				this.areaOptions = this.existingAreas.map(
+					(area) =>
+						({
+							value: area.name,
+							label: area.name,
+						}) as FormFieldSelectOption,
+				);
+				this.existingAreasLoading = false;
+			},
+			(err) => {
+				console.error("Couldn't fetch areas: " + err);
+				this.existingAreasLoading = false;
+			},
+		);
+	}
 
+	addArea() {
+		const newArea = (this.newAreaInput['query'] || '').trim().toLowerCase();
+
+		if (newArea.length > 0) {
+			this.areas.add(newArea);
+			this.newAreaInput['query'] = '';
+		}
+	}
+
+	handleAreaInputKeyPress(event: KeyboardEvent) {
+		if (event.keyCode === 13 /* Enter */) {
+			this.addArea();
+			this.newAreaInput.nativeElement.focus();
+			event.preventDefault();
+		}
+	}
+
+	removeArea(area: string) {
+		this.areas.delete(area);
+	}
 	enableAlignments() {
 		this.alignmentsEnabled = true;
 		if (this.badgeClassForm.controls.alignments.length === 0) {
@@ -1448,6 +1509,7 @@ export class BadgeClassEditFormComponent
 				this.existingBadgeClass.imageFrame = imageFrame;
 				this.existingBadgeClass.alignments = this.alignmentsEnabled ? formState.alignments : [];
 				this.existingBadgeClass.tags = Array.from(this.tags);
+				this.existingBadgeClass.areas = Array.from(this.areas);
 				this.existingBadgeClass.courseUrl = formState.courseUrl;
 				this.existingBadgeClass.criteria = await this.getCriteriaAsBadgeLanguage(
 					formState.criteria,
@@ -1508,6 +1570,7 @@ export class BadgeClassEditFormComponent
 					image: !imageFrame ? formState.badge_image : null,
 					imageFrame: imageFrame,
 					tags: Array.from(this.tags),
+					areas: Array.from(this.areas),
 					alignment: this.alignmentsEnabled ? formState.alignments : [],
 					expiration: expirationDays,
 					criteria: await this.getCriteriaAsBadgeLanguage(formState.criteria, formState.badge_language),

--- a/src/app/issuer/models/badgeclass-api.model.ts
+++ b/src/app/issuer/models/badgeclass-api.model.ts
@@ -36,6 +36,7 @@ export interface ApiBadgeClassForCreation {
 	extensions?: object;
 
 	tags?: string[];
+	areas?: string[];
 	alignment?: ApiBadgeClassAlignment[];
 	expiration?: number; // in days
 	copy_permissions?: BadgeClassCopyPermissions[];

--- a/src/app/issuer/models/badgeclass.model.ts
+++ b/src/app/issuer/models/badgeclass.model.ts
@@ -118,6 +118,12 @@ export class BadgeClass extends ManagedEntity<ApiBadgeClass, BadgeClassRef> {
 	set tags(tags: string[]) {
 		this.apiModel.tags = tags;
 	}
+	get areas(): string[] {
+		return this.apiModel.areas;
+	}
+	set areas(areas: string[]) {
+		this.apiModel.areas = areas;
+	}
 
 	get extension() {
 		return this.apiModel.extensions;

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -579,7 +579,9 @@
 		"alreadyShared": "Der Badge wurde bereits für ein Netzwerk freigegeben.",
 		"unknownRecipient": "Empfänger:in unbekannt",
 		"badgeLanguage": "Sprache des Badges",
-		"badgeLanguageHint": "(und der Badge-Mail inkl. zugehörigem PDF-Zertifikat)"
+		"badgeLanguageHint": "(und der Badge-Mail inkl. zugehörigem PDF-Zertifikat)",
+		"tag": "Tag",
+		"area": "Bereich"
 	},
 	"CreateBadge": {
 		"chooseBadgeCategory": "Kategorie wählen",
@@ -649,6 +651,9 @@
 		"newTag": "Einen Tag eingeben...",
 		"tagDoesNotExist": "Dieser Tag existiert noch nicht",
 		"tagInfo": "Tags verschlagworten {{items}} und helfen Lernenden auf OEB bei der Suche von {{items2}} zu bestimmten Themen.",
+		"addAreas": "Bereiche hinzufügen",
+		"newArea": "Einen Bereich eingeben...",
+		"areaDoesNotExist": "Diese Bereich existiert noch nicht",
 		"removeAlignment": "Verknpüfung entfernen",
 		"removeAlignmentInfo": "Bist du sicher, dass du die Verknpüfung(en) entfernen möchtest? ",
 		"irreversibleAction": "Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -580,7 +580,9 @@
 		"alreadyShared": "The badge was already shared on a network.",
 		"unknownRecipient": "Recipient unknown",
 		"badgeLanguage": "Language of this badge",
-		"badgeLanguageHint": "(and of the badge email incl. corresponding PDF certificate)"
+		"badgeLanguageHint": "(and of the badge email incl. corresponding PDF certificate)",
+		"tag": "Tag",
+		"area": "Area"
 	},
 	"CreateBadge": {
 		"chooseBadgeCategory": "Choose category",
@@ -650,6 +652,9 @@
 		"newTag": "Enter a tag...",
 		"tagDoesNotExist": "This tag does not exist yet",
 		"tagInfo": "Tags help categorize {{items}} and help learners on OEB search for {{items2}} on specific topics.",
+		"addAreas": "Add Areas",
+		"newArea": "Enter an area...",
+		"areaDoesNotExist": "This area does not exist yet",
 		"removeAlignment": "Remove link",
 		"removeAlignmentInfo": "Are you sure you want to remove the link(s)? ",
 		"irreversibleAction": "This action cannot be undone.",


### PR DESCRIPTION
## Summary
Implements the frontend for the badge area feature as described in [#1879](https://github.com/open-educational-badges/badgr-ui/issues/1879). Areas can be assigned during badge creation/editing and are displayed on the badge detail page sidebar.

## Changes
- Add `areas` field to `ApiBadgeClassForCreation` and `BadgeClass` model
- Refactor `getEntityTags` → `getEntityMetadata` in `CatalogService` and add `getBadgeAreas()`
- Add area management logic to `BadgeClassEditFormComponent`: `fetchAreas()`, `addArea()`, `removeArea()`, `handleAreaInputKeyPress()`
- Add area `ng-autocomplete` field with `[minQueryLength]="3"` inside the Tags step
- Display area in badge detail sidebar via `loadConfig()` and `PageConfig` type
- Add translation keys to `de.json` and `en.json`

## Acceptance Criteria Coverage
- ✅ Area field available under Tags step as an optional field.
- ✅ Free-text input supported
- ✅ Dropdown suggestions on field click
- ✅ Autocomplete triggers after 3 characters
- ✅ Suggestions selectable by click
- ✅ Added as tag below, removable with x
- ✅ At least one area assignable per badge
- ✅ Areas auto-created on badge save
- ✅ Area stored with badge
- ✅ Area displayed on badge detail page sidebar

