### PR TITLE
fix(issuer): preserve network overlay when editing network badge

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -646,7 +646,7 @@ export class BadgeClassEditFormComponent
 			if (badgeClass.imageFrame) {
 				// regenerating the upload image for the issuer image in case it changed via copying
 				// or if it was not part of the badge image yet
-				this.generateUploadImage(this.currentImage, this.badgeClassForm.value, true, true);
+				this.generateUploadImage(this.currentImage, this.badgeClassForm.value, !this.issuer?.is_network, true);
 			} else if (badgeClass.image) {
 				const dataUrl = await this.urlToDataUrl(badgeClass.image);
 				this.currentImage = dataUrl;

--- a/src/app/issuer/components/badgeclass-edit/badgeclass-edit.component.html
+++ b/src/app/issuer/components/badgeclass-edit/badgeclass-edit.component.html
@@ -1,4 +1,4 @@
-<ng-container *bgAwaitPromises="[issuerLoaded]">
+<ng-container *bgAwaitPromises="[issuerLoaded, badgeClassLoaded]">
 	<form-message></form-message>
 
 	<header class="topbar">

--- a/src/app/issuer/components/badgeclass-edit/badgeclass-edit.component.ts
+++ b/src/app/issuer/components/badgeclass-edit/badgeclass-edit.component.ts
@@ -8,6 +8,7 @@ import { BaseAuthenticatedRoutableComponent } from '../../../common/pages/base-a
 import { SessionService } from '../../../common/services/session.service';
 import { MessageService } from '../../../common/services/message.service';
 import { Issuer } from '../../models/issuer.model';
+import { Network } from '../../network.model';
 
 import { BadgeClassManager } from '../../services/badgeclass-manager.service';
 import { IssuerManager } from '../../services/issuer-manager.service';
@@ -56,7 +57,7 @@ export class BadgeClassEditComponent extends BaseAuthenticatedRoutableComponent 
 	}
 	readonly badgeClassPlaceholderImageUrl = '../../../../breakdown/static/images/placeholderavatar.svg';
 
-	issuer: Issuer;
+	issuer: Issuer | Network;
 	badgeClassEditForm: FormGroup;
 
 	submitted = false;
@@ -108,7 +109,7 @@ export class BadgeClassEditComponent extends BaseAuthenticatedRoutableComponent 
 				),
 		);
 
-		this.issuerLoaded = issuerManager.issuerBySlug(this.issuerSlug).then(
+		this.issuerLoaded = issuerManager.issuerOrNetworkBySlug(this.issuerSlug).then(
 			(issuer) => {
 				this.issuer = issuer;
 				this.editBadgeCrumbs = [

--- a/src/app/issuer/services/issuer-manager.service.ts
+++ b/src/app/issuer/services/issuer-manager.service.ts
@@ -105,22 +105,13 @@ export class IssuerManager {
 	}
 
 	issuerOrNetworkBySlug(issuerSlug: IssuerSlug): Promise<Issuer | Network> {
-		try {
-			const loadIssuer = this.issuerBySlug(issuerSlug);
-			const loadNetwork = this.networkBySlug(issuerSlug);
-			return Promise.allSettled([loadIssuer, loadNetwork]).then(([i, n]) => {
-				if (i.status === 'fulfilled' && !i.value.is_network) return i.value;
-				else if (i.status === 'fulfilled' && i.value.is_network) {
-					if (n.status === 'fulfilled') {
-						return n.value;
-					} else {
-						throw new Error('Could not properly load network information');
-					}
-				}
-			});
-		} catch (e) {
-			this.throwError(`Issuer/Network Slug '${issuerSlug}' not found`);
-		}
+		const loadIssuer = this.issuerBySlug(issuerSlug);
+		const loadNetwork = this.networkBySlug(issuerSlug);
+		return Promise.allSettled([loadIssuer, loadNetwork]).then(([i, n]) => {
+			if (i.status === 'fulfilled' && !i.value.is_network) return i.value;
+			if (n.status === 'fulfilled') return n.value;
+			throw new Error(`Issuer/Network Slug '${issuerSlug}' not found`);
+		});
 	}
 
 	issuersByUrls(issuerUrls: string[]): Promise<Issuer[]> {


### PR DESCRIPTION
Issue #2020 

Overview of changes: 

- Load issuer as "Issuer | Network" in edit component.
- Await both issuerLoaded and badgeClassLoaded before rendering edit form
- Fix issuerOrNetworkBySlug to correctly return Network when issuer slug belongs to a network
- Use !issuer.is_network instead of hardcoded true value for useIssuerImageInBadge in edit form preview

See also: [badgr-server changes](https://github.com/open-educational-badges/badgr-server/pull/747)