### PR TITLE
fix(share-badge): remove double URL encoding in LinkedIn share dialog

### DIFF
--- a/src/app/common/dialogs/oeb-dialogs/share-badge-dialog.component.ts
+++ b/src/app/common/dialogs/oeb-dialogs/share-badge-dialog.component.ts
@@ -126,8 +126,8 @@ export class ShareBadgeDialogComponent implements AfterViewInit {
 
 		const shareParams = {
 			startTask: 'CERTIFICATION_NAME', // this is the name LinkedIn has given the task
-			name: encodeURIComponent(this.context.badge.badgeClass.name),
-			organizationName: encodeURIComponent(this.context.badge.badgeClass.issuer.name),
+			name: this.context.badge.badgeClass.name,
+			organizationName: this.context.badge.badgeClass.issuer.name,
 			issueYear: `${this.context.badge.issueDate.getFullYear()}`,
 			issueMonth: ('0' + (this.context.badge.issueDate.getMonth() + 1)).slice(-2),
 			expirationYear: this.context.badge.expiresDate
@@ -136,7 +136,7 @@ export class ShareBadgeDialogComponent implements AfterViewInit {
 			expirationMonth: this.context.badge.expiresDate
 				? ('0' + (this.context.badge.expiresDate.getMonth() + 1)).slice(-2)
 				: undefined,
-			certUrl: encodeURIComponent(this.shareUrl),
+			certUrl: this.shareUrl,
 			certId: this.context.badge.slug,
 			organizationId: this.issuer.linkedinId?.length > 0 ? this.issuer.linkedinId : undefined,
 		};


### PR DESCRIPTION
See Issue #2046 

Values passed to URLSearchParams were being manually encodeURIComponent'd first, causing double-encoding. LinkedIn decodes one layer, leaving Competent%20Developer and https%3A%2F%2F...etc. displayed literally in the name and credential URL fields. Removing the manual encoding lets URLSearchParams handle it correctly.