### PR TITLE
fix(lp): change lp background color and undo filtering

### DIFF
--- a/src/app/common/components/bg-learningpathcard.ts
+++ b/src/app/common/components/bg-learningpathcard.ts
@@ -41,7 +41,7 @@ type MatchOrProgressType = { match?: string; progress?: number };
 		<ng-template #contentTemplate>
 			<div class="tw-flex tw-flex-col tw-h-full">
 				<div
-					class="tw-bg-[var(--color-lightgray)] tw-w-full tw-relative tw-h-[175px] tw-items-center tw-flex tw-justify-center tw-p-2 tw-rounded-[3px]"
+					class="tw-bg-white tw-w-full tw-relative tw-h-[175px] tw-items-center tw-flex tw-justify-center tw-p-2 tw-rounded-[3px]"
 				>
 					@if (!completed()) {
 						<div class="tw-absolute tw-top-[10px] tw-right-[10px]">

--- a/src/app/recipient/components/recipient-earned-badges-overview/recipient-earned-badges-overview.component.ts
+++ b/src/app/recipient/components/recipient-earned-badges-overview/recipient-earned-badges-overview.component.ts
@@ -162,7 +162,6 @@ export default class RecipientEarnedBadgesOverview {
 	searchQuery = signal<string>('');
 	filteredBadges = computed(() => {
 		return this.badges()
-			.filter((b) => b.getExtension('extensions:CategoryExtension', {}).Category !== 'learningpath')
 			.filter(MatchingAlgorithm.badgeMatcher(this.searchQuery()))
 			.sort(this.sortBadgesBy(this.sortOption()));
 	});


### PR DESCRIPTION
Addresses the following comments: 
- [Learning path background color should be white](https://github.com/open-educational-badges/badgr-ui/issues/2048#issuecomment-4477925328)
- [Show completed MDs in the 'Badges' tab of backpack, not just in 'Learning Paths' tab](https://github.com/open-educational-badges/badgr-ui/issues/2048#issuecomment-4478018832)