### PR TITLE
fix(perf): reduce initial bundle size and improve frontend load times

### DIFF
--- a/src/app/common/components/issuer/oeb-issuer-detail.component.html
+++ b/src/app/common/components/issuer/oeb-issuer-detail.component.html
@@ -109,7 +109,7 @@
 											[attr.aria-label]="'Visit ' + network.name + ' network'"
 										>
 											<img
-												class="tw-w-[33px]"
+												class="tw-w-[33px] tw-h-[33px] tw-aspect-square"
 												[src]="network.image"
 												[alt]="network.name + ' logo'"
 											/>
@@ -141,7 +141,7 @@
 											[attr.aria-label]="'Visit ' + partner.name + ' profile'"
 										>
 											<img
-												class="tw-w-[33px]"
+												class="tw-w-[33px] tw-h-[33px] tw-aspect-square"
 												[src]="partner.image"
 												[alt]="partner.name + ' logo'"
 											/>
@@ -601,7 +601,11 @@
 						class="tw-px-2 tw-py-2 tw-gap-2 tw-flex tw-items-center tw-font-semibold tw-text-lg tw-leading-[130%] tw-uppercase tw-text-oebblack tw-cursor-pointer"
 						[routerLink]="['/issuer/networks', group.networkIssuer.slug]"
 					>
-						<img class="tw-w-12" [src]="group.networkIssuer.image" alt="Network Logo" />
+						<img
+							class="tw-w-12 tw-h-12 tw-aspect-square"
+							[src]="group.networkIssuer.image"
+							alt="Network Logo"
+						/>
 						<span>{{ group.issuerName }}</span>
 					</div>
 

--- a/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
+++ b/src/app/common/dialogs/export-pdf-dialog/export-pdf-dialog.component.ts
@@ -3,7 +3,6 @@ import { Component, ElementRef, Renderer2, ViewChild, SecurityContext, inject } 
 import { BaseDialog } from '../base-dialog';
 import { RecipientBadgeInstance } from '../../../recipient/models/recipient-badge.model';
 
-import jsPDF from 'jspdf';
 import { ApiRecipientBadgeIssuer } from '../../../recipient/models/recipient-badge-api.model';
 import { RecipientBadgeCollection } from '../../../recipient/models/recipient-badge-collection.model';
 import { UserProfile } from '../../model/user-profile.model';
@@ -36,7 +35,7 @@ export class ExportPdfDialog extends BaseDialog {
 	badgeResults: BadgeResult[] | null = null;
 	badgePdf: string | null = null;
 	pdfSrc: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl('about:blank');
-	doc: jsPDF = null;
+	doc: any = null;
 	themeColor: string;
 	pdfError: Error;
 
@@ -105,9 +104,10 @@ export class ExportPdfDialog extends BaseDialog {
 	}
 
 	// disclaimer: unfinished
-	generateBadgeCollectionPdf(collection: RecipientBadgeCollection) {
+	async generateBadgeCollectionPdf(collection: RecipientBadgeCollection) {
 		this.pdfError = undefined;
 		const badges: RecipientBadgeInstance[] = collection.badges;
+		const { default: jsPDF } = await import('jspdf');
 		this.doc = new jsPDF('l', 'mm', 'a4', true);
 
 		let yPos = 20;

--- a/src/app/common/services/cms-manager.service.ts
+++ b/src/app/common/services/cms-manager.service.ts
@@ -4,12 +4,21 @@ import { Observable } from 'rxjs';
 import { UpdatableSubject } from '../util/updatable-subject';
 import { CmsApiMenu } from '../model/cms-api.model';
 
+const CMS_MENU_CACHE_KEY = 'cms_menu_cache';
+
 @Injectable({ providedIn: 'root' })
 export class CmsManager {
 	cmsApiService = inject(CmsApiService);
 
 	_menus = new UpdatableSubject<CmsApiMenu>(() => {
+		const cached = localStorage.getItem(CMS_MENU_CACHE_KEY);
+		if (cached) {
+			try {
+				this._menus.safeNext(JSON.parse(cached));
+			} catch {}
+		}
 		this.cmsApiService.getMenus().then((m) => {
+			localStorage.setItem(CMS_MENU_CACHE_KEY, JSON.stringify(m));
 			this._menus.safeNext(m);
 		});
 	});

--- a/src/app/common/services/user-profile-api.service.ts
+++ b/src/app/common/services/user-profile-api.service.ts
@@ -33,12 +33,22 @@ export class UserProfileApiService extends BaseHttpApiService {
 		this.messageService = messageService;
 	}
 
+	private _profilePromise: Promise<ApiUserProfile> | null = null;
+
 	getProfile() {
 		if (this.sessionService.isLoggedIn) {
-			return this.get<ApiUserProfile>('/v1/user/profile').then((r) => r.body);
+			if (!this._profilePromise) {
+				this._profilePromise = this.get<ApiUserProfile>('/v1/user/profile').then((r) => r.body);
+			}
+			return this._profilePromise;
 		} else {
+			this._profilePromise = null;
 			return Promise.reject('No user logged in');
 		}
+	}
+
+	invalidateProfileCache() {
+		this._profilePromise = null;
 	}
 
 	updatePassword(newPassword: string, currentPassword: string) {
@@ -49,6 +59,7 @@ export class UserProfileApiService extends BaseHttpApiService {
 	}
 
 	updateProfile(profile: ApiUserProfile) {
+		this._profilePromise = null;
 		return this.put<ApiUserProfile>('/v1/user/profile', profile).then((r) => r.body);
 	}
 
@@ -56,8 +67,17 @@ export class UserProfileApiService extends BaseHttpApiService {
 		return this.delete('/v1/user/profile');
 	}
 
+	private _emailsPromise: Promise<ApiUserProfileEmail[]> | null = null;
+
 	fetchEmails() {
-		return this.get<ApiUserProfileEmail[]>('/v1/user/emails').then((r) => r.body);
+		if (!this._emailsPromise) {
+			this._emailsPromise = this.get<ApiUserProfileEmail[]>('/v1/user/emails').then((r) => r.body);
+		}
+		return this._emailsPromise;
+	}
+
+	invalidateEmailsCache() {
+		this._emailsPromise = null;
 	}
 
 	fetchSocialAccounts() {
@@ -65,10 +85,12 @@ export class UserProfileApiService extends BaseHttpApiService {
 	}
 
 	addEmail(email: string) {
+		this._emailsPromise = null;
 		return this.post<ApiUserProfileEmail>('/v1/user/emails', { email: email }).then((r) => r.body);
 	}
 
 	removeEmail(emailId: number) {
+		this._emailsPromise = null;
 		return this.delete('/v1/user/emails/' + emailId);
 	}
 

--- a/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.html
+++ b/src/app/issuer/components/badgeclass-detail/badgeclass-detail.component.html
@@ -19,7 +19,7 @@
 				}
 				@for (qrGroup of networkQrCodeApiAwards; track qrGroup.issuer.slug) {
 					<div class="tw-mt-8 tw-mb-2 tw-flex tw-gap-2 tw-items-center">
-						<img class="tw-w-11" [src]="qrGroup.issuer.image" alt="Issuer Logo" />
+						<img class="tw-w-11 tw-h-11 tw-aspect-square" [src]="qrGroup.issuer.image" alt="Issuer Logo" />
 						<span class="tw-text-oebblack tw-text-lg tw-font-semibold tw-uppercase">{{
 							qrGroup.issuer.name
 						}}</span>
@@ -54,7 +54,11 @@
 							@if (!partner.has_access && partner.instance_count > 0) {
 								<div class="tw-mb-4">
 									<div class="tw-mt-8 tw-mb-2 tw-flex tw-gap-2 tw-items-center">
-										<img class="tw-w-11" [src]="partner.issuer.image" alt="Partner Logo" />
+										<img
+											class="tw-w-11 tw-h-11 tw-aspect-square"
+											[src]="partner.issuer.image"
+											alt="Partner Logo"
+										/>
 										<span class="tw-text-oebblack tw-font-bold tw-text-lg tw-uppercase">{{
 											partner.issuer.name
 										}}</span>
@@ -68,7 +72,11 @@
 							} @else if (partner.instances.length) {
 								<div>
 									<div class="tw-mt-8 tw-flex tw-gap-2 tw-items-center">
-										<img class="tw-w-11" [src]="partner.issuer.image" alt="Partner Logo" />
+										<img
+											class="tw-w-11 tw-h-11 tw-aspect-square"
+											[src]="partner.issuer.image"
+											alt="Partner Logo"
+										/>
 										<span class="tw-text-oebblack tw-font-bold tw-text-lg tw-uppercase">{{
 											partner.issuer.name
 										}}</span>

--- a/src/app/issuer/components/issuer-detail/issuer-detail.component.ts
+++ b/src/app/issuer/components/issuer-detail/issuer-detail.component.ts
@@ -95,7 +95,10 @@ export class IssuerDetailComponent extends BaseAuthenticatedRoutableComponent im
 			},
 		];
 
-		this.issuerLoaded = this.issuerManager.issuerBySlug(this.issuerSlug).then(
+		const issuerPromise = this.issuerManager.issuerBySlug(this.issuerSlug);
+		const badgesUpdatePromise = this.badgeClassService.badgesList.updateList();
+
+		this.issuerLoaded = issuerPromise.then(
 			(issuer) => {
 				this.issuer = issuer;
 				if (issuer.is_network) {
@@ -108,22 +111,6 @@ export class IssuerDetailComponent extends BaseAuthenticatedRoutableComponent im
 					{ title: this.translate.instant('NavItems.myInstitutions'), routerLink: ['/issuer/issuers'] },
 					{ title: this.issuer.name, routerLink: ['/issuer/issuers/' + this.issuer.slug] },
 				];
-
-				this.badgesLoaded = this.badgeClassService.badgesList
-					.updateList()
-					.then(() => firstValueFrom(this.badgeClassService.badgesByIssuerUrl$))
-					.then((badgesByIssuer) => {
-						const cmp = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
-						this.badges = (badgesByIssuer[this.issuer.issuerUrl] || []).sort((a, b) =>
-							cmp(b.createdAt, a.createdAt),
-						);
-					})
-					.catch((error) => {
-						this.messageService.reportAndThrowError(
-							`Failed to load badges for ${this.issuer ? this.issuer.name : this.issuerSlug}`,
-							error,
-						);
-					});
 			},
 			(error) => {
 				this.messageService.reportLoadingError(
@@ -132,6 +119,21 @@ export class IssuerDetailComponent extends BaseAuthenticatedRoutableComponent im
 				);
 			},
 		);
+
+		this.badgesLoaded = Promise.all([issuerPromise, badgesUpdatePromise])
+			.then(() => firstValueFrom(this.badgeClassService.badgesByIssuerUrl$))
+			.then((badgesByIssuer) => {
+				const cmp = (a, b) => (a === b ? 0 : a < b ? -1 : 1);
+				this.badges = (badgesByIssuer[this.issuer.issuerUrl] || []).sort((a, b) =>
+					cmp(b.createdAt, a.createdAt),
+				);
+			})
+			.catch((error) => {
+				this.messageService.reportAndThrowError(
+					`Failed to load badges for ${this.issuer ? this.issuer.name : this.issuerSlug}`,
+					error,
+				);
+			});
 
 		this.profileEmailsLoaded = this.profileManager.userProfilePromise
 			.then((profile) => profile.emails.loadedPromise)

--- a/src/app/issuer/components/issuer-list/issuer-list.component.html
+++ b/src/app/issuer/components/issuer-list/issuer-list.component.html
@@ -284,7 +284,7 @@
 									class="tw-p-2 hover:tw-bg-[var(--color-lightpurple)] tw-cursor-pointer tw-flex tw-items-center tw-gap-2"
 									(click)="selectIssuerFromDropdown(issuer)"
 								>
-									<img [src]="issuer.image" width="24" class="tw-aspect-square" />
+									<img [src]="issuer.image" width="24" height="24" class="tw-aspect-square" />
 									<span>{{ issuer.name }}</span>
 								</li>
 							}

--- a/src/app/issuer/components/issuer-staff/issuer-staff.component.html
+++ b/src/app/issuer/components/issuer-staff/issuer-staff.component.html
@@ -8,7 +8,7 @@
 			<div class="tw-gap-4 tw-flex tw-items-center">
 				@if (issuer().image) {
 					<img
-						class="md:tw-w-[93px] tw-w-[70px] tw-min-w-[70px]"
+						class="md:tw-w-[93px] tw-w-[70px] tw-min-w-[70px] md:tw-h-[93px] tw-h-[70px] tw-aspect-square"
 						[src]="issuer().image"
 						alt="{{ issuer().name }} logo "
 					/>

--- a/src/app/issuer/issuer.routes.ts
+++ b/src/app/issuer/issuer.routes.ts
@@ -5,8 +5,6 @@ import { IssuerEditComponent } from './components/issuer-edit/issuer-edit.compon
 import { BadgeClassCreateComponent } from './components/badgeclass-create/badgeclass-create.component';
 import { BadgeClassEditComponent } from './components/badgeclass-edit/badgeclass-edit.component';
 import { BadgeClassDetailComponent } from './components/badgeclass-detail/badgeclass-detail.component';
-import { BadgeClassIssueComponent } from './components/badgeclass-issue/badgeclass-issue.component';
-import { BadgeClassIssueBulkAwardComponent } from './components/badgeclass-issue-bulk-award/badgeclass-issue-bulk-award.component';
 import { IssuerStaffComponent } from './components/issuer-staff/issuer-staff.component';
 import { BadgeClassEditQrComponent } from './components/badgeclass-edit-qr/badgeclass-edit-qr.component';
 import { BadgeClassIssueQrComponent } from './components/badgeclass-issue-qr/badgeclass-issue-qr.component';
@@ -19,9 +17,6 @@ import { BadgeClassEditIssuedComponent } from './components/badgeclass-edit-issu
 import { NetworkCreateComponent } from './components/network-create/network-create.component';
 import { NetworkDashboardComponent } from './components/network-dashboard/network-dashboard.component';
 import { NetworkInviteConfirmationComponent } from './components/network-invite-confirmation/network-invite-confirmation.component';
-import { PDFTemplateCreateComponent } from './components/pdftemplate-create/pdftemplate-create.component';
-import { PDFTemplateEditComponent } from './components/pdftemplate-edit/pdftemplate-edit.component';
-import { LearningPathEditPDFTemplateComponent } from './components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component';
 import { NetworkEditComponent } from './components/network-edit/network-edit.component';
 import { NetworkBadgeAnalysisComponent } from './components/network-badge-analysis/network-badge-analysis.component';
 import { DashboardCompetencyTrackingComponent } from './components/network-competency-tracking/network-competency-tracking.component';
@@ -129,23 +124,34 @@ export const routes = [
 	},
 	{
 		path: 'issuers/:issuerSlug/badges/:badgeSlug/issue',
-		component: BadgeClassIssueComponent,
+		loadComponent: () =>
+			import('./components/badgeclass-issue/badgeclass-issue.component').then((m) => m.BadgeClassIssueComponent),
 	},
 	{
 		path: 'issuers/:issuerSlug/badges/:badgeSlug/bulk-import',
-		component: BadgeClassIssueBulkAwardComponent,
+		loadComponent: () =>
+			import('./components/badgeclass-issue-bulk-award/badgeclass-issue-bulk-award.component').then(
+				(m) => m.BadgeClassIssueBulkAwardComponent,
+			),
 	},
 	{
 		path: 'issuers/:issuerSlug/pdftemplates/create',
-		component: PDFTemplateCreateComponent,
+		loadComponent: () =>
+			import('./components/pdftemplate-create/pdftemplate-create.component').then(
+				(m) => m.PDFTemplateCreateComponent,
+			),
 	},
 	{
 		path: 'issuers/:issuerSlug/pdftemplates/:pdfTemplateSlug/edit',
-		component: PDFTemplateEditComponent,
+		loadComponent: () =>
+			import('./components/pdftemplate-edit/pdftemplate-edit.component').then((m) => m.PDFTemplateEditComponent),
 	},
 	{
 		path: 'issuers/:issuerSlug/learningpaths/:learningPathSlug/pdftemplate',
-		component: LearningPathEditPDFTemplateComponent,
+		loadComponent: () =>
+			import('./components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component').then(
+				(m) => m.LearningPathEditPDFTemplateComponent,
+			),
 	},
 	{
 		path: 'issuers/:networkSlug/badge-analysis',

--- a/src/app/profile/components/profile-edit/profile-edit.component.html
+++ b/src/app/profile/components/profile-edit/profile-edit.component.html
@@ -38,7 +38,7 @@
 			</div>
 
 			<div class="l-flex l-flex-1x">
-				<a class="button button-secondary" [routerLink]="['../profile']">{{ 'General.cancel ' | translate }}</a>
+				<a class="button button-secondary" [routerLink]="['../profile']">{{ 'General.cancel' | translate }}</a>
 
 				<button type="submit" class="button">{{ 'General.save' | translate }}</button>
 			</div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1123,7 +1123,7 @@
 		"descriptionText": "With each badge, a PDF certificate in OEB design is automatically sent to your apprentices. Here you can upload <strong>personalized PDF backgrounds for your institution</strong>, which can then <strong>be selected</strong> instead of the OEB design <strong>when awarding the badge</strong>.",
 		"createdTemplates": "Created templates",
 		"editor": "PDF Template Editor",
-		"createPDFTemplate": "Create pdf template",
+		"createPDFTemplate": "Create PDF template",
 		"createHeading": "Create a new template",
 		"backgroundHeading": "Upload your own PDF background:",
 		"createdSuccessfully": "Your pdf template has been created successfully.",


### PR DESCRIPTION
- Lazy load 5 heavy issuer routes so fabric and jsPDF are only
  loaded when those routes are actually visited
- Dynamically import jsPDF in the collection PDF dialog
- Load issuer and badges in parallel on the issuer detail page
- Add promise-level caching for user profile and emails API calls
- Add localStorage stale-while-revalidate cache for CMS menu
- Add explicit image dimensions across issuer templates to reduce CLS
- Fix trailing space in profile-edit translation key (General.cancel)
- Fix "PDF" capitalisation in en.json