### PR TITLE
fix(perf): skip all-issuers list load on badge creation flow

### DIFF
--- a/src/app/issuer/components/badgeclass-create/badgeclass-create.component.ts
+++ b/src/app/issuer/components/badgeclass-create/badgeclass-create.component.ts
@@ -68,7 +68,7 @@ export class BadgeClassCreateComponent extends BaseAuthenticatedRoutableComponen
 			this.issuerLoaded = Promise.resolve(this.issuer);
 		} else {
 			this.issuerLoaded = this.issuerManager
-				.issuerOrNetworkBySlug(this.issuerSlug)
+				.issuerOrNetworkBySlugDirect(this.issuerSlug)
 				.then((issuer) => {
 					this.issuer = issuer;
 					return issuer;

--- a/src/app/issuer/components/badgeclass-select-type/badgeclass-select-type.component.ts
+++ b/src/app/issuer/components/badgeclass-select-type/badgeclass-select-type.component.ts
@@ -51,7 +51,7 @@ export class BadgeClassSelectTypeComponent extends BaseAuthenticatedRoutableComp
 		});
 		this.issuerSlug = this.route.snapshot.params['issuerSlug'];
 
-		this.issuerLoaded = this.issuerManager.issuerOrNetworkBySlug(this.issuerSlug).then((issuer) => {
+		this.issuerLoaded = this.issuerManager.issuerOrNetworkBySlugDirect(this.issuerSlug).then((issuer) => {
 			this.issuer = issuer;
 			this.breadcrumbLinkEntries = [
 				{ title: 'Issuers', routerLink: ['/issuer'] },

--- a/src/app/issuer/components/learningpath-create/learningpath-create.component.ts
+++ b/src/app/issuer/components/learningpath-create/learningpath-create.component.ts
@@ -60,7 +60,7 @@ export class LearningPathCreateComponent extends BaseAuthenticatedRoutableCompon
 
 		this.issuerSlug = this.route.snapshot.params['issuerSlug'];
 
-		this.issuerLoaded = this.issuerManager.issuerBySlug(this.issuerSlug).then((issuer) => {
+		this.issuerLoaded = this.issuerManager.issuerBySlugDirect(this.issuerSlug).then((issuer) => {
 			this.issuer = issuer;
 			this.breadcrumbLinkEntries = [
 				{ title: 'Issuers', routerLink: ['/issuer'] },

--- a/src/app/issuer/services/issuer-manager.service.ts
+++ b/src/app/issuer/services/issuer-manager.service.ts
@@ -77,6 +77,22 @@ export class IssuerManager {
 		return this.issuerApiService.getIssuer(issuerSlug).then((apiIssuer) => this.issuersList.addOrUpdate(apiIssuer));
 	}
 
+	networkBySlugDirect(networkSlug: IssuerSlug): Promise<Network> {
+		return this.networkApiService
+			.getNetwork(networkSlug)
+			.then((apiNetwork) => this.networksList.addOrUpdate(apiNetwork));
+	}
+
+	async issuerOrNetworkBySlugDirect(issuerSlug: IssuerSlug): Promise<Issuer | Network> {
+		try {
+			const issuer = await this.issuerBySlugDirect(issuerSlug);
+			if (!issuer.is_network) return issuer;
+			return await this.networkBySlugDirect(issuerSlug);
+		} catch {
+			return this.networkBySlugDirect(issuerSlug);
+		}
+	}
+
 	issuerBySlug(issuerSlug: IssuerSlug): Promise<Issuer> {
 		return firstValueFrom(
 			combineLatest([


### PR DESCRIPTION
Replace issuerOrNetworkBySlug with direct single-issuer API calls in
BadgeClassSelectTypeComponent, BadgeClassCreateComponent, and
LearningPathCreateComponent, reducing the ~9s navigation delay to ~100ms.