### PR TITLE
feat(pdf-template): move PDF template selection from issuance to badge creation

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.html
@@ -939,7 +939,11 @@
 					</cdk-step>
 				}
 
-				<cdk-step label="Tags" [optional]="true" errorMessage="Bitte Tags auswählen">
+				<cdk-step
+					[label]="'CreateBadge.optionalDetails' | translate"
+					[optional]="true"
+					errorMessage="Bitte Tags auswählen"
+				>
 					<div class="section tw-text-oebblack tw-mt-6">
 						<div>
 							@if (badgeCategory !== 'competency' || existingBadgeClass) {
@@ -1020,6 +1024,41 @@
 					<h2 hlmH2 class="tw-pt-1 tw-px-1 tw-mr-auto !tw-text-oebblack !tw-font-bold">
 						{{ 'CreateBadge.optionalBadgeDetails' | translate }}
 					</h2>
+
+					@if (
+						pdfTemplateManager.pdfEditorAvailable() &&
+						(!issuer?.quotas || issuer?.quotas?.quotas['PDFEDITOR'].quota)
+					) {
+						<section class="section tw-text-oebblack tw-mt-6">
+							<h2 hlmH2 class="!tw-text-oebblack tw-pb-4">
+								{{ 'PDFTemplate.backgroundLabel' | translate }}
+							</h2>
+							<div class="tw-mt-4 tw-mb-4 tw-flex tw-flex-wrap tw-gap-6 tw-items-end">
+								<oeb-select
+									class="tw-block tw-flex-grow"
+									[options]="selectPDFTemplateOptions"
+									[control]="badgeClassForm.rawControlMap.pdf_template"
+									[noTopMargin]="true"
+									label="{{ 'PDFTemplate.backgroundLabel' | translate }}"
+								></oeb-select>
+								@if (issuer?.currentUserStaffMember?.canEditBadge) {
+									<oeb-button
+										class="tw-whitespace-nowrap tw-flex-grow"
+										[routerLink]="['/issuer/issuers', issuer.slug]"
+										fragment="pdf-templates"
+										[text]="'PDFTemplate.createCustomPDFTemplate' | translate"
+										width="full_width"
+										size="sm"
+										variant="secondary"
+										weight="normal"
+										icon="lucidePlus"
+										iconSize="sm"
+										[iconLeft]="true"
+									></oeb-button>
+								}
+							</div>
+						</section>
+					}
 
 					@if (category === 'competency') {
 						<div class="section tw-text-oebblack tw-mt-6">

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -130,9 +130,9 @@ export class BadgeClassEditFormComponent
 	protected pdfTemplateManager = inject(PDFTemplateManager);
 
 	baseUrl: string;
-	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplatesPromise: Promise<void>;
 	pdfTemplates: ApiPDFTemplate[] = [];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
+	selectPDFTemplateOptions: Array<{ label: string; value: string | null }> = [];
 	badgeCategory: string;
 
 	aiCompetenciesLoading = false;
@@ -1037,7 +1037,7 @@ export class BadgeClassEditFormComponent
 			.then((pdfTemplates) => {
 				this.pdfTemplates = pdfTemplates.sort((a, b) => a.name.localeCompare(b.name));
 				this.selectPDFTemplateOptions = [
-					{ label: 'OEB Standard', value: null },
+					{ label: this.translate.instant('PDFTemplate.oebDesign'), value: null },
 					...this.pdfTemplates.map((t) => ({ label: t.name, value: t.slug })),
 				];
 				// Defer so Angular's render cycle creates the oeb-select before writeValue fires.

--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -23,6 +23,7 @@ import {
 	ReactiveFormsModule,
 } from '@angular/forms';
 import { Md5 } from 'ts-md5';
+import { RouterLink } from '@angular/router';
 import { BaseAuthenticatedRoutableComponent } from '../../../common/pages/base-authenticated-routable.component';
 import { MessageService } from '../../../common/services/message.service';
 import {
@@ -71,6 +72,8 @@ import { LanguageService, lngs } from '~/common/services/language.service';
 import { QuotaInformationComponent } from '../quota-information/quota-information.component';
 import { QuotaExceededDialog } from '../issuer-quotas-quota-exceeded-dialog/issuer-quotas-quota-exceeded-dialog.component';
 import { HlmDialogService } from '../../../components/spartan/ui-dialog-helm/src/lib/hlm-dialog.service';
+import { PDFTemplateManager } from '~/issuer/services/pdftemplate-manager.service';
+import { ApiPDFTemplate } from '../../../common/model/pdftemplate-api.model';
 
 const MAX_STUDYLOAD_HRS: number = 10_000;
 const MAX_HRS_PER_COMPETENCY: number = 999;
@@ -107,6 +110,7 @@ const MAX_HRS_PER_COMPETENCY: number = 999;
 		UpperCasePipe,
 		QuotaInformationComponent,
 		QuotaExceededDialog,
+		RouterLink,
 	],
 })
 export class BadgeClassEditFormComponent
@@ -123,8 +127,12 @@ export class BadgeClassEditFormComponent
 	protected catalogService = inject(CatalogService);
 	private languageService = inject(LanguageService);
 	private readonly _hlmDialogService = inject(HlmDialogService);
+	protected pdfTemplateManager = inject(PDFTemplateManager);
 
 	baseUrl: string;
+	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplates: ApiPDFTemplate[] = [];
+	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
 	badgeCategory: string;
 
 	aiCompetenciesLoading = false;
@@ -197,6 +205,12 @@ export class BadgeClassEditFormComponent
 			this.existingBadgeClass = badgeClass;
 			this.existing = true;
 			this.initFormFromExisting(this.existingBadgeClass);
+			// If templates already loaded, re-trigger writeValue so the select shows the saved template.
+			// This handles the race where loadPDFTemplates() resolved before this @Input arrived.
+			if (this.selectPDFTemplateOptions.length > 0) {
+				const ctrl = this.badgeClassForm.rawControl.controls['pdf_template'];
+				setTimeout(() => ctrl.setValue(badgeClass.pdfTemplate ?? null, { emitEvent: false }), 0);
+			}
 		}
 	}
 
@@ -441,7 +455,8 @@ export class BadgeClassEditFormComponent
 		.addControl('expiration_unit', 'days', Validators.required)
 		.addArray('criteria', this.criteriaForm)
 
-		.addControl('copy_permissions_allow_others', false);
+		.addControl('copy_permissions_allow_others', false)
+		.addControl('pdf_template', null);
 
 	@ViewChild('badgeStudio')
 	badgeStudio: BadgeStudioComponent;
@@ -637,6 +652,7 @@ export class BadgeClassEditFormComponent
 				translationKey: null,
 			})),
 			copy_permissions_allow_others: this.existing ? badgeClass.canCopy('others') : false,
+			pdf_template: badgeClass.pdfTemplate ?? null,
 		});
 
 		// Keep the badge category in sync directly from the source badge. The `category`
@@ -688,6 +704,7 @@ export class BadgeClassEditFormComponent
 	ngOnInit() {
 		super.ngOnInit();
 		this.fetchTags();
+		this.loadPDFTemplates();
 
 		this.durationOptions = getDurationOptions(this.translate);
 
@@ -1012,6 +1029,24 @@ export class BadgeClassEditFormComponent
 				this.existingTagsLoading = false;
 			},
 		);
+	}
+
+	loadPDFTemplates() {
+		this.pdfTemplatesPromise = this.pdfTemplateManager
+			.getPDFTemplatesForIssuer(this.issuer.slug)
+			.then((pdfTemplates) => {
+				this.pdfTemplates = pdfTemplates.sort((a, b) => a.name.localeCompare(b.name));
+				this.selectPDFTemplateOptions = [
+					{ label: 'OEB Standard', value: null },
+					...this.pdfTemplates.map((t) => ({ label: t.name, value: t.slug })),
+				];
+				// Defer so Angular's render cycle creates the oeb-select before writeValue fires.
+				// Use existingBadgeClass.pdfTemplate as source of truth (handles race where badge class
+				// @Input hasn't arrived yet; the @Input setter re-triggers setValue if it arrives later).
+				const ctrl = this.badgeClassForm.rawControl.controls['pdf_template'];
+				const savedValue = this.existingBadgeClass?.pdfTemplate ?? ctrl.value;
+				setTimeout(() => ctrl.setValue(savedValue ?? null, { emitEvent: false }), 0);
+			});
 	}
 
 	addTag() {
@@ -1521,6 +1556,7 @@ export class BadgeClassEditFormComponent
 					};
 				}
 				this.existingBadgeClass.copyPermissions = copy_permissions;
+				this.existingBadgeClass.pdfTemplate = formState.pdf_template ?? null;
 
 				this.savePromise = this.existingBadgeClass.save();
 			} else {
@@ -1572,6 +1608,7 @@ export class BadgeClassEditFormComponent
 						),
 					},
 					copy_permissions: copy_permissions,
+					pdf_template: formState.pdf_template ?? null,
 				} as ApiBadgeClassForCreation;
 				if (this.currentImage) {
 					badgeClassData.extensions = {

--- a/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.component.html
+++ b/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.component.html
@@ -13,6 +13,40 @@
 				{{ 'CreateBadge.optionalBadgeDetails' | translate }}
 			</h2>
 			<form [formGroup]="badgeClassForm.rawControl" #formElem (ngSubmit)="onSubmit()" novalidate>
+				@if (
+					pdfTemplateManager.pdfEditorAvailable() &&
+					(!issuer?.quotas || issuer?.quotas?.quotas['PDFEDITOR'].quota)
+				) {
+					<section class="section tw-text-oebblack tw-mt-6">
+						<h2 hlmH2 class="!tw-text-oebblack tw-pb-4">
+							{{ 'PDFTemplate.backgroundLabel' | translate }}
+						</h2>
+						<div class="tw-mt-4 tw-mb-4 tw-flex tw-flex-wrap tw-gap-6 tw-items-end">
+							<oeb-select
+								class="tw-block tw-flex-grow"
+								[options]="selectPDFTemplateOptions"
+								[control]="badgeClassForm.rawControlMap.pdf_template"
+								[noTopMargin]="true"
+								label="{{ 'PDFTemplate.backgroundLabel' | translate }}"
+							></oeb-select>
+							@if (issuer?.currentUserStaffMember?.canEditBadge) {
+								<oeb-button
+									class="tw-whitespace-nowrap tw-flex-grow"
+									[routerLink]="['/issuer/issuers', issuerSlug]"
+									fragment="pdf-templates"
+									[text]="'PDFTemplate.createCustomPDFTemplate' | translate"
+									width="full_width"
+									size="sm"
+									variant="secondary"
+									weight="normal"
+									icon="lucidePlus"
+									iconSize="sm"
+									[iconLeft]="true"
+								></oeb-button>
+							}
+						</div>
+					</section>
+				}
 				<section class="section tw-text-oebblack tw-text-lg tw-pb-6">
 					<h2 hlmH2 class="!tw-text-oebblack tw-mb-4">{{ 'Badge.copyBadgeHeadline' | translate }}</h2>
 					<p class="tw-italic tw-mb-4" [innerHTML]="'Badge.copyBadgeDescription1' | translate"></p>
@@ -58,7 +92,7 @@
 							[id]="'duration-type'"
 							ariaLabel="chooseDuration"
 							[control]="badgeClassForm.rawControlMap.expiration_unit"
-							[optionMap]="durationOptions"
+							[optionMap]="durationOptions || {}"
 						></oeb-select>
 					</div>
 					<p class="tw-italic tw-text-purple" [innerHTML]="'CreateBadge.expirationInfo' | translate"></p>

--- a/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
+++ b/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
@@ -67,9 +67,9 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 	breadcrumbLinkEntries: LinkEntry[] = [];
 
 	durationOptions = null;
-	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplatesPromise: Promise<void>;
 	pdfTemplates: ApiPDFTemplate[] = [];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
+	selectPDFTemplateOptions: Array<{ label: string; value: string | null }> = [];
 
 	@ViewChild('formElem')
 	formElem: ElementRef<HTMLFormElement>;
@@ -143,7 +143,7 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 			.then(async (pdfTemplates) => {
 				this.pdfTemplates = pdfTemplates.sort((a, b) => a.name.localeCompare(b.name));
 				this.selectPDFTemplateOptions = [
-					{ label: 'OEB Standard', value: null },
+					{ label: this.translate.instant('PDFTemplate.oebDesign'), value: null },
 					...this.pdfTemplates.map((t) => ({ label: t.name, value: t.slug })),
 				];
 				// Ensure badge class has loaded so the form value is set before we re-trigger writeValue.

--- a/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
+++ b/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
@@ -22,9 +22,12 @@ import { HlmH1, HlmH2 } from '@spartan-ng/helm/typography';
 import { HlmP } from '@spartan-ng/helm/typography';
 import { PositiveIntegerOrNullValidator } from '~/common/validators/positive-integer-or-null.validator';
 import { OebInputComponent } from '~/components/input.component';
-import { OebSelectComponent } from '~/components/select.component';
+import { OebSelectComponent, FormFieldSelectOption } from '~/components/select.component';
 import { getDurationOptions, expirationToDays, ExpirationUnit } from '~/common/util/expiration-util';
 import { UrlValidator } from '~/common/validators/url.validator';
+import { PDFTemplateManager } from '../../services/pdftemplate-manager.service';
+import { ApiPDFTemplate } from '~/common/model/pdftemplate-api.model';
+import { RouterLink } from '@angular/router';
 
 @Component({
 	templateUrl: 'badgeclass-edit-issued.component.html',
@@ -42,6 +45,7 @@ import { UrlValidator } from '~/common/validators/url.validator';
 		HlmP,
 		OebInputComponent,
 		OebSelectComponent,
+		RouterLink,
 	],
 })
 export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComponent implements OnInit {
@@ -49,6 +53,7 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 	protected messageService = inject(MessageService);
 	protected issuerManager = inject(IssuerManager);
 	protected badgeManager = inject(BadgeClassManager);
+	protected pdfTemplateManager = inject(PDFTemplateManager);
 	private configService = inject(AppConfigService);
 	private translate = inject(TranslateService);
 
@@ -62,6 +67,9 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 	breadcrumbLinkEntries: LinkEntry[] = [];
 
 	durationOptions = null;
+	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplates: ApiPDFTemplate[] = [];
+	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
 
 	@ViewChild('formElem')
 	formElem: ElementRef<HTMLFormElement>;
@@ -74,9 +82,10 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 			,
 			Validators.max(10000),
 		])
-		.addControl('expiration_unit', 'days');
+		.addControl('expiration_unit', 'days')
+		.addControl('pdf_template', null);
 
-	savePromise: Promise<BadgeClass> | null = null;
+	savePromise: Promise<unknown> | null = null;
 
 	constructor() {
 		const sessionService = inject(SessionService);
@@ -102,6 +111,7 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 					copy_permissions_allow_others: badgeClass.canCopy('others'),
 					expiration: badgeClass.expiration,
 					expiration_unit: 'days',
+					pdf_template: badgeClass.pdfTemplate ?? null,
 				});
 			},
 			(error) =>
@@ -124,6 +134,24 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 	ngOnInit() {
 		super.ngOnInit();
 		this.durationOptions = getDurationOptions(this.translate);
+		this.loadPDFTemplates();
+	}
+
+	loadPDFTemplates() {
+		this.pdfTemplatesPromise = this.pdfTemplateManager
+			.getPDFTemplatesForIssuer(this.issuerSlug)
+			.then(async (pdfTemplates) => {
+				this.pdfTemplates = pdfTemplates.sort((a, b) => a.name.localeCompare(b.name));
+				this.selectPDFTemplateOptions = [
+					{ label: 'OEB Standard', value: null },
+					...this.pdfTemplates.map((t) => ({ label: t.name, value: t.slug })),
+				];
+				// Ensure badge class has loaded so the form value is set before we re-trigger writeValue.
+				await this.badgeClassLoaded;
+				const ctrl = this.badgeClassForm.rawControl.controls['pdf_template'];
+				const savedValue = ctrl.value;
+				setTimeout(() => ctrl.setValue(savedValue, { emitEvent: false }), 0);
+			});
 	}
 
 	badgeClassCreated(promise: Promise<BadgeClass>) {
@@ -151,6 +179,7 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 		this.badgeClass.expiration = expirationDays;
 		this.badgeClass.copyPermissions = copy_permissions;
 		this.badgeClass.courseUrl = formState.courseUrl;
+		this.badgeClass.pdfTemplate = formState.pdf_template ?? null;
 		try {
 			this.savePromise = this.badgeClass.save();
 			await this.savePromise;

--- a/src/app/issuer/components/badgeclass-issue-bulk-award-confirmation/badgeclass-issue-bulk-award-confirmation.component.ts
+++ b/src/app/issuer/components/badgeclass-issue-bulk-award-confirmation/badgeclass-issue-bulk-award-confirmation.component.ts
@@ -41,10 +41,6 @@ import { DateValidator } from '~/common/validators/date.validator';
 import { DateRangeValidator } from '~/common/validators/date-range.validator';
 import { IssuerManager } from '../../services/issuer-manager.service';
 import { Issuer } from '../../models/issuer.model';
-import { OebSelectComponent } from '../../../components/select.component';
-import { FormFieldSelectOption } from '~/common/components/formfield-select';
-import { PDFTemplateManager } from '~/issuer/services/pdftemplate-manager.service';
-import { ApiPDFTemplate } from '../../../common/model/pdftemplate-api.model';
 import { OptionalDetailsComponent } from '../optional-details/optional-details.component';
 import { setupActivityOnlineSync } from '~/common/util/activity-place-sync-helper';
 import { UrlValidator } from '~/common/validators/url.validator';
@@ -62,7 +58,6 @@ import { Network } from '~/issuer/network.model';
 		NgClass,
 		FormsModule,
 		OptionalDetailsComponent,
-		OebSelectComponent,
 		RouterLink,
 	],
 })
@@ -81,7 +76,6 @@ export class BadgeclassIssueBulkAwardConformation
 	protected taskService = inject(TaskPollingManagerService);
 	protected translate = inject(TranslateService);
 	protected issuerManager = inject(IssuerManager);
-	protected pdfTemplateManager = inject(PDFTemplateManager);
 
 	readonly transformedImportData = input<TransformedImportData>(undefined);
 	readonly badgeSlug = input<string>(undefined);
@@ -113,8 +107,7 @@ export class BadgeclassIssueBulkAwardConformation
 		.addArray(
 			'evidence_items',
 			typedFormGroup().addControl('narrative', '').addControl('evidence_url', '', UrlValidator.validUrl),
-		)
-		.addControl('pdftemplate', null);
+		);
 
 	buttonDisabledClass = true;
 	buttonDisabledAttribute = true;
@@ -156,10 +149,6 @@ export class BadgeclassIssueBulkAwardConformation
 
 	private focusedRow: BulkIssueData | null = null;
 
-	pdfTemplatesPromise: Promise<unknown>;
-	pdfTemplates: ApiPDFTemplate[];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
-
 	constructor() {
 		const sessionService = inject(SessionService);
 		const router = inject(Router);
@@ -182,26 +171,8 @@ export class BadgeclassIssueBulkAwardConformation
 		this.optionalDetailsForm.controls.courseUrl.setValue(this.badgeClass().courseUrl ?? null);
 		this.badgeInstanceCourseUrl.set(this.optionalDetailsForm.controls.courseUrl.value);
 
-		this.issuerManager.myIssuers$.subscribe(async (issuers) => {
+		this.issuerManager.myIssuers$.subscribe((issuers) => {
 			this.issuer.set(issuers.find((i) => i.slug === this.issuerSlug()));
-
-			if (
-				this.authService.isLoggedIn &&
-				this.issuer() instanceof Issuer &&
-				this.issuer().currentUserStaffMember
-			) {
-				this.getPDFTemplatesForIssuerApi(this.issuer().slug);
-				await this.pdfTemplatesPromise;
-
-				this.selectPDFTemplateOptions = this.pdfTemplates.map((t) => ({
-					label: t.name,
-					value: t.slug,
-				}));
-				this.selectPDFTemplateOptions.push({
-					label: this.translate.instant('PDFTemplate.oebDesign'),
-					value: null,
-				});
-			}
 		});
 
 		if (this.badgeClass().isNetworkBadge) {
@@ -321,7 +292,6 @@ export class BadgeclassIssueBulkAwardConformation
 				extensions: extensions,
 				activity_start_date: activityStartDate,
 				activity_end_date: activityEndDate,
-				pdftemplate: formState.pdftemplate,
 				activity_zip: formState.activity_zip,
 				activity_city: formState.activity_city,
 				activity_online: formState.activity_online,
@@ -397,16 +367,5 @@ export class BadgeclassIssueBulkAwardConformation
 		if (!this.transformedImportData().validRowsTransformed.size) {
 			this.disableActionButton();
 		}
-	}
-
-	getPDFTemplatesForIssuerApi(issuerSlug) {
-		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(issuerSlug)
-			.then(
-				(pdfTemplates) =>
-					(this.pdfTemplates = pdfTemplates.sort(
-						(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-					)),
-			);
 	}
 }

--- a/src/app/issuer/components/badgeclass-issue/badgeclass-issue.component.html
+++ b/src/app/issuer/components/badgeclass-issue/badgeclass-issue.component.html
@@ -29,72 +29,37 @@
 							</div>
 							<p size="sm" hlmP>{{ 'Issuer.badgePreview' | translate }}</p>
 						</div>
-						<div class="tw-w-[300px] tw-text-center tw-h-[300px]" [hidden]="pdfTemplateSelected()">
+						<div class="tw-w-[300px] tw-text-center tw-h-[300px]">
 							<div
-								class="tw-px-6 tw-py-4 tw-border-purple tw-border-solid tw-border tw-rounded-[15px] tw-relative tw-h-full tw-mb-1 tw-overflow-hidden tw-flex"
+								class="tw-border-purple tw-border-solid tw-border tw-rounded-[15px] tw-relative tw-h-full tw-mb-1 tw-overflow-hidden tw-flex tw-items-center tw-justify-center"
 							>
-								<img
-									class="tw-inline-block tw-absolute tw-right-0 tw-left-0 tw-m-auto tw-top-0 tw-z-0 tw-h-full"
-									alt="Certificate Preview"
-									src="assets/oeb/images/issuerPage/certificate_preview.svg"
-								/>
-
-								<img
-									class="badge-image badgeimage-center tw-z-10 tw-relative tw-w-[35%] tw-mb-[15%] tw-self-center"
-									[loaded-src]="previewB64Img"
-									[loading-src]="badgeLoadingImageUrl"
-									[error-src]="badgeFailedImageUrl"
-								/>
-							</div>
-							<p size="sm" hlmP [innerHTML]="'Issuer.certPreview' | translate"></p>
-						</div>
-
-						<div class="tw-w-[300px] tw-text-center tw-h-[300px]" [hidden]="!pdfTemplateSelected()">
-							<div
-								class="tw-px-6 tw-py-4 tw-border-purple tw-border-solid tw-border tw-rounded-[15px] tw-relative tw-h-full tw-mb-1 tw-overflow-hidden tw-flex tw-justify-center l-flex-aligncenter"
-							>
-								<canvas id="previewCanvas"></canvas>
+								@if (pdfTemplateForPreview) {
+									<canvas
+										id="badgeIssuePreviewCanvas"
+										[attr.width]="pdfTemplateForPreview.format === 0 ? 794 : 1123"
+										[attr.height]="pdfTemplateForPreview.format === 0 ? 1123 : 794"
+										[class.portrait]="pdfTemplateForPreview.format === 0"
+										[class.landscape]="pdfTemplateForPreview.format !== 0"
+									>
+									</canvas>
+								} @else {
+									<img
+										class="tw-inline-block tw-absolute tw-right-0 tw-left-0 tw-m-auto tw-top-0 tw-z-0 tw-h-full"
+										alt="Certificate Preview"
+										src="assets/oeb/images/issuerPage/certificate_preview.svg"
+									/>
+									<img
+										class="badge-image badgeimage-center tw-z-10 tw-relative tw-w-[35%] tw-mb-[15%] tw-self-center"
+										[loaded-src]="previewB64Img"
+										[loading-src]="badgeLoadingImageUrl"
+										[error-src]="badgeFailedImageUrl"
+									/>
+								}
 							</div>
 							<p size="sm" hlmP [innerHTML]="'Issuer.certPreview' | translate"></p>
 						</div>
 					</div>
 				</div>
-
-				@if (
-					pdfTemplateManager.pdfEditorAvailable() &&
-					(!issuer?.quotas || issuer?.quotas?.quotas['PDFEDITOR'].quota)
-				) {
-					<div class="tw-mt-10 tw-mb-10 tw-flex tw-flex-wrap tw-gap-6 tw-items-end">
-						<oeb-select
-							class="tw-block tw-flex-grow"
-							[options]="selectPDFTemplateOptions"
-							[control]="issueForm.rawControlMap.pdftemplate"
-							[noTopMargin]="true"
-							label="{{ 'PDFTemplate.backgroundLabel' | translate }}"
-						></oeb-select>
-
-						@if (issuer.currentUserStaffMember.canEditBadge) {
-							<oeb-button
-								[id]="'create-new-pdftemplate-btn'"
-								[class.disabled]="!issuer.canCreateBadge"
-								class="tw-whitespace-nowrap tw-flex-grow"
-								[routerLink]="['/issuer/issuers', issuer.slug]"
-								fragment="pdf-templates"
-								[disabled]="!issuer.currentUserStaffMember"
-								[text]="'PDFTemplate.createCustomPDFTemplate' | translate"
-								width="full_width"
-								size="sm"
-								variant="secondary"
-								weight="normal"
-								icon="lucidePlus"
-								iconSize="sm"
-								[iconLeft]="true"
-								[umamiEvent]="'create-pdftemplate'"
-							>
-							</oeb-button>
-						}
-					</div>
-				}
 
 				<div class="tw-border-purple tw-border-solid tw-border tw-p-6 tw-rounded-[15px] tw-my-6">
 					<span hlmP [innerHTML]="'Issuer.batchAwardText1' | translate"></span>&nbsp;

--- a/src/app/issuer/components/badgeclass-issue/badgeclass-issue.component.ts
+++ b/src/app/issuer/components/badgeclass-issue/badgeclass-issue.component.ts
@@ -12,6 +12,9 @@ import { MdImgValidator } from '../../../common/validators/md-img.validator';
 import { BadgeInstanceManager } from '../../services/badgeinstance-manager.service';
 import { BadgeClassManager } from '../../services/badgeclass-manager.service';
 import { IssuerManager } from '../../services/issuer-manager.service';
+import { PDFTemplateManager } from '../../services/pdftemplate-manager.service';
+import { PDFTemplate } from '../../models/pdftemplate.model';
+import { PreviewCanvas } from '../../../common/util/pdftemplate-util';
 
 import { Issuer } from '../../models/issuer.model';
 import { BadgeClass } from '../../models/badgeclass.model';
@@ -42,11 +45,6 @@ import { OebButtonComponent } from '../../../components/oeb-button.component';
 import { HlmH1, HlmP } from '@spartan-ng/helm/typography';
 import { OebCollapsibleComponent } from '~/components/oeb-collapsible.component';
 import { DateRangeValidator } from '~/common/validators/date-range.validator';
-import { FormFieldSelectOption } from '~/common/components/formfield-select';
-import { PDFTemplateManager } from '~/issuer/services/pdftemplate-manager.service';
-import { ApiPDFTemplate } from '../../../common/model/pdftemplate-api.model';
-import { PreviewCanvas } from '~/common/util/pdftemplate-util';
-import { PDFTemplate } from '~/issuer/models/pdftemplate.model';
 import { NgIcon } from '@ng-icons/core';
 import { OebSeparatorComponent } from '~/components/oeb-separator.component';
 import { OptionalDetailsComponent } from '../optional-details/optional-details.component';
@@ -61,10 +59,6 @@ import { Network } from '~/issuer/network.model';
 	styles: [
 		`
 			:host ::ng-deep {
-				brn-collapsible[data-state='open'] > button > span {
-					font-weight: bold !important;
-				}
-
 				.canvas-container {
 					width: 100% !important;
 					height: 100% !important;
@@ -97,7 +91,6 @@ import { Network } from '~/issuer/network.model';
 		HlmP,
 		RouterLink,
 		OebInputComponent,
-		OebSelectComponent,
 		OebCheckboxComponent,
 		SvgIconComponent,
 		FormFieldMarkdown,
@@ -119,10 +112,10 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 	protected issuerManager = inject(IssuerManager);
 	protected badgeClassManager = inject(BadgeClassManager);
 	protected badgeInstanceManager = inject(BadgeInstanceManager);
+	protected pdfTemplateManager = inject(PDFTemplateManager);
 	protected dialogService = inject(CommonDialogsService);
 	protected configService = inject(AppConfigService);
 	protected translate = inject(TranslateService);
-	protected pdfTemplateManager = inject(PDFTemplateManager);
 	protected authService: SessionService;
 
 	readonly badgeLoadingImageUrl = '../../../breakdown/static/images/badge-loading.svg';
@@ -205,12 +198,11 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 		.addArray(
 			'evidence_items',
 			typedFormGroup().addControl('narrative', '').addControl('evidence_url', '', UrlValidator.validUrl),
-		)
-		.addControl('pdftemplate', null);
-
+		);
 	badgeClass: BadgeClass;
 
 	previewB64Img: string;
+	pdfTemplateForPreview: PDFTemplate | null = null;
 
 	subscriptions: Subscription[] = [];
 
@@ -223,11 +215,6 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 		url: 'URL',
 		// telephone: "Telephone",
 	};
-
-	pdfTemplatesPromise: Promise<unknown>;
-	pdfTemplates: ApiPDFTemplate[];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
-	pdfTemplatePreviewCanvas: PreviewCanvas;
 
 	constructor() {
 		const sessionService = inject(SessionService);
@@ -258,6 +245,32 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 						.then((img) => {
 							this.previewB64Img = img.image_url;
 						});
+
+					if (badgeClass.pdfTemplate) {
+						this.pdfTemplateManager
+							.getPDFTemplateForIssuer(this.issuerSlug, badgeClass.pdfTemplate)
+							.then((template) => {
+								this.pdfTemplateForPreview = template;
+								const formatStr = template.format === 0 ? 'portrait' : 'landscape';
+								const alignmentStr = template.alignment === 0 ? 'left' : 'center';
+								setTimeout(() => {
+									new PreviewCanvas(
+										this.translate,
+										formatStr,
+										template.scale,
+										alignmentStr,
+										template.posX,
+										template.posY,
+										template.image,
+										1,
+										'badgeIssuePreviewCanvas',
+										this.previewB64Img || '/breakdown/static/images/pdfPreviewBadgeImage.svg',
+										false,
+									);
+								}, 0);
+							})
+							.catch((err) => console.error('Failed to load PDF template preview', err));
+					}
 
 					this.breadcrumbLinkEntries = [
 						{ title: 'Issuers', routerLink: ['/issuer'] },
@@ -291,83 +304,10 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 		}
 
 		await this.issuerLoaded;
-
-		if (this.authService.isLoggedIn && this.issuer instanceof Issuer && this.issuer.currentUserStaffMember) {
-			this.getPDFTemplatesForIssuerApi(this.issuer.slug);
-			await this.pdfTemplatesPromise;
-
-			this.selectPDFTemplateOptions = this.pdfTemplates.map((t) => ({
-				label: t.name,
-				value: t.slug,
-			}));
-			this.selectPDFTemplateOptions.push({
-				label: this.translate.instant('PDFTemplate.oebDesign'),
-				value: null,
-			});
-		}
-
-		this.issueForm.rawControl.controls['pdftemplate'].valueChanges.subscribe((v) => {
-			if (v != null) {
-				for (let pt of this.pdfTemplates) {
-					if (pt.slug == v) {
-						if (this.pdfTemplatePreviewCanvas === undefined) {
-							this.setHTMLCanvasDimensions(pt);
-
-							this.pdfTemplatePreviewCanvas = new PreviewCanvas(
-								this.translate,
-								pt.format == 0 ? 'portrait' : 'landscape',
-								pt.scale,
-								pt.alignment == 0 ? 'left' : 'center',
-								pt.posX,
-								pt.posY,
-								pt.image,
-								1,
-								'previewCanvas',
-								this.previewB64Img || this.badgeClass.image,
-								false,
-							);
-						} else {
-							this.setHTMLCanvasDimensions(pt);
-
-							this.pdfTemplatePreviewCanvas.updateValues(
-								pt.format == 0 ? 'portrait' : 'landscape',
-								pt.scale,
-								pt.alignment == 0 ? 'left' : 'center',
-								pt.posX,
-								pt.posY,
-								pt.image,
-							);
-						}
-
-						break;
-					}
-				}
-			}
-		});
 	}
 
 	ngOnDestroy() {
 		this.subscriptions.forEach((s) => s.unsubscribe());
-	}
-
-	setHTMLCanvasDimensions(pt: ApiPDFTemplate) {
-		let canvas = document.querySelector<HTMLCanvasElement>('#previewCanvas');
-
-		if (pt.format == 0) {
-			canvas.width = 794;
-			canvas.height = 1123;
-			canvas.classList.remove('landscape');
-			canvas.classList.add('portrait');
-		} else {
-			canvas.width = 1123;
-			canvas.height = 794;
-			canvas.classList.remove('portrait');
-			canvas.classList.add('landscape');
-		}
-	}
-
-	pdfTemplateSelected() {
-		return this.issueForm.controls.pdftemplate.value != null;
 	}
 
 	addEvidence() {
@@ -433,7 +373,6 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 				extensions,
 				activity_start_date: activityStartDate,
 				activity_end_date: activityEndDate,
-				pdftemplate: formState.pdftemplate,
 				activity_zip: formState.activity_zip,
 				activity_city: formState.activity_city,
 				activity_online: formState.activity_online,
@@ -497,17 +436,6 @@ export class BadgeClassIssueComponent extends BaseAuthenticatedRoutableComponent
 				variant: 'success',
 			},
 		});
-	}
-
-	getPDFTemplatesForIssuerApi(issuerSlug) {
-		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(issuerSlug)
-			.then(
-				(pdfTemplates) =>
-					(this.pdfTemplates = pdfTemplates.sort(
-						(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-					)),
-			);
 	}
 
 	async checkQuotasDialog(quota: string) {

--- a/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
+++ b/src/app/issuer/components/edit-qr-form/edit-qr-form.component.html
@@ -69,58 +69,6 @@
 					/>
 				</div>
 
-				<!-- PDF Template Section -->
-				@if (
-					issuer.currentUserStaffMember.canEditBadge &&
-					pdfTemplateManager.pdfEditorAvailable() &&
-					(!issuer?.quotas || issuer?.quotas?.quotas['PDFEDITOR'].quota)
-				) {
-					<div
-						class="tw-mb-10 tw-flex tw-bg-white tw-border-purple tw-border-solid tw-border tw-rounded-[15px] tw-p-6 tw-flex-col tw-gap-2"
-					>
-						<span
-							class="tw-text-oebblack tw-text-lg tw-uppercase tw-font-semibold md:tw-leading-[28px] md:tw-text-[20px] tw-leading-[19px] tw-text-[14px]"
-						>
-							@if (!editing) {
-								<span class="tw-font-normal tw-italic">Optional:</span>
-							}
-							{{ 'PDFTemplate.ownPDFBackground' | translate }}
-						</span>
-
-						<span class="tw-text-purple tw-italic tw-leading-[18.2px]">
-							{{ 'PDFTemplate.noTemplateDefaultDesign' | translate }}
-						</span>
-
-						<div class="tw-flex tw-flex-col tw-gap-6 tw-max-w-[300px]">
-							<oeb-select
-								class="tw-block tw-flex-grow"
-								[options]="selectPDFTemplateOptions"
-								[control]="qrForm.rawControlMap.pdftemplate"
-								[noTopMargin]="true"
-							></oeb-select>
-
-							<oeb-button
-								[id]="'create-new-pdftemplate-btn'"
-								[class.disabled]="!issuer.canCreateBadge"
-								class="tw-whitespace-nowrap tw-flex-grow"
-								[routerLink]="['/issuer/issuers', issuer.slug]"
-								fragment="pdf-templates"
-								[disabled]="!issuer.currentUserStaffMember"
-								[text]="'PDFTemplate.createCustomPDFTemplate' | translate"
-								width="full_width"
-								size="sm"
-								variant="secondary"
-								weight="normal"
-								icon="lucidePlus"
-								iconSize="sm"
-								[iconLeft]="true"
-								[umamiEvent]="'create-pdftemplate'"
-							>
-							</oeb-button>
-						</div>
-					</div>
-				}
-
 				<!-- Notifications Section -->
 				@if (editing) {
 					<span

--- a/src/app/issuer/components/edit-qr-form/edit-qr-form.component.ts
+++ b/src/app/issuer/components/edit-qr-form/edit-qr-form.component.ts
@@ -23,10 +23,6 @@ import { IssuerManager } from '~/issuer/services/issuer-manager.service';
 import { Issuer } from '~/issuer/models/issuer.model';
 import { environment } from '../../../../environments/environment';
 import { DateRangeValidator } from '~/common/validators/date-range.validator';
-import { OebSelectComponent } from '../../../components/select.component';
-import { FormFieldSelectOption } from '~/common/components/formfield-select';
-import { PDFTemplateManager } from '~/issuer/services/pdftemplate-manager.service';
-import { ApiPDFTemplate } from '../../../common/model/pdftemplate-api.model';
 import { OptionalDetailsComponent } from '../optional-details/optional-details.component';
 import { setupActivityOnlineSync } from '~/common/util/activity-place-sync-helper';
 import { Subscription } from 'rxjs';
@@ -45,7 +41,6 @@ import { UrlValidator } from '~/common/validators/url.validator';
 		OebButtonComponent,
 		TranslatePipe,
 		OptionalDetailsComponent,
-		OebSelectComponent,
 		RouterLink,
 	],
 })
@@ -55,7 +50,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 	protected badgeClassManager = inject(BadgeClassManager);
 	protected issuerManager = inject(IssuerManager);
 	protected _location = inject(Location);
-	protected pdfTemplateManager = inject(PDFTemplateManager);
 	protected authService: SessionService;
 
 	static datePipe = new DatePipe('de');
@@ -101,10 +95,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 
 	subscriptions: Subscription[] = [];
 
-	pdfTemplatesPromise: Promise<unknown>;
-	pdfTemplates: ApiPDFTemplate[];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
-
 	qrForm = typedFormGroup([this.missingStartDate.bind(this)])
 		.addControl('title', '', Validators.required)
 		.addControl('createdBy', '', Validators.required)
@@ -130,8 +120,7 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 		.addControl('badgeclass_id', '', Validators.required)
 		.addControl('issuer_id', '', Validators.required)
 		.addControl('courseUrl', null, UrlValidator.validUrl)
-		.addControl('notifications', false)
-		.addControl('pdftemplate', null);
+		.addControl('notifications', false);
 
 	constructor() {
 		const route = inject(ActivatedRoute);
@@ -187,11 +176,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 
 		if (this.qrSlug) {
 			this.qrCodeApiService.getQrCode(this.issuerSlug, this.badgeSlug, this.qrSlug).then((qrCode) => {
-				let pdftemplate = null;
-				if (qrCode.pdftemplate != null) {
-					pdftemplate = qrCode.pdftemplate.replace('PDFTemplate', '');
-				}
-
 				this.qrForm.setValue({
 					title: qrCode.title,
 					createdBy: qrCode.createdBy,
@@ -221,7 +205,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 					badgeclass_id: qrCode.badgeclass_id,
 					issuer_id: qrCode.issuer_id,
 					notifications: qrCode.notifications,
-					pdftemplate: pdftemplate,
 					courseUrl: qrCode.course_url,
 				});
 			});
@@ -250,20 +233,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 		}
 
 		await this.issuerLoaded;
-
-		if (this.authService.isLoggedIn && this.issuer instanceof Issuer && this.issuer.currentUserStaffMember) {
-			this.getPDFTemplatesForIssuerApi(this.issuer.slug);
-			await this.pdfTemplatesPromise;
-
-			this.selectPDFTemplateOptions = this.pdfTemplates.map((t) => ({
-				label: t.name,
-				value: t.slug,
-			}));
-			this.selectPDFTemplateOptions.push({
-				label: this.translate.instant('PDFTemplate.oebDesign'),
-				value: null,
-			});
-		}
 	}
 
 	ngOnDestroy() {
@@ -336,7 +305,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 					badgeclass_id: this.badgeSlug,
 					issuer_id: this.issuerSlug,
 					notifications: formState.notifications,
-					pdftemplate: formState.pdftemplate,
 					course_url: formState.courseUrl,
 				})
 				.then((qrcode) => {
@@ -377,7 +345,6 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 					expires_at: formState.expires_at ? expiresDate.toISOString() : undefined,
 					valid_from: formState.valid_from ? new Date(formState.valid_from).toISOString() : undefined,
 					notifications: formState.notifications,
-					pdftemplate: formState.pdftemplate,
 					course_url: formState.courseUrl,
 				})
 				.then((qrcode) => {
@@ -393,16 +360,5 @@ export class EditQrFormComponent extends BaseAuthenticatedRoutableComponent impl
 					]);
 				});
 		}
-	}
-
-	getPDFTemplatesForIssuerApi(issuerSlug) {
-		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(issuerSlug)
-			.then(
-				(pdfTemplates) =>
-					(this.pdfTemplates = pdfTemplates.sort(
-						(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-					)),
-			);
 	}
 }

--- a/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
+++ b/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
@@ -289,9 +289,9 @@ export class LearningPathEditFormComponent
 
 	selectMinBadgesOptions: FormFieldSelectOption[] = [];
 
-	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplatesPromise: Promise<void>;
 	pdfTemplates: ApiPDFTemplate[];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
+	selectPDFTemplateOptions: Array<{ label: string; value: string | null }> = [];
 
 	constructor() {
 		const sessionService = inject(SessionService);
@@ -1086,14 +1086,11 @@ export class LearningPathEditFormComponent
 	}
 
 	getPDFTemplatesForIssuerApi(issuerSlug) {
-		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(issuerSlug)
-			.then(
-				(pdfTemplates) =>
-					(this.pdfTemplates = pdfTemplates.sort(
-						(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-					)),
+		this.pdfTemplatesPromise = this.pdfTemplateManager.getPDFTemplatesForIssuer(issuerSlug).then((pdfTemplates) => {
+			this.pdfTemplates = pdfTemplates.sort(
+				(a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
 			);
+		});
 	}
 
 	checkQuotasDialog(quota: string) {

--- a/src/app/issuer/components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component.ts
+++ b/src/app/issuer/components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component.ts
@@ -54,9 +54,9 @@ export class LearningPathEditPDFTemplateComponent extends BaseAuthenticatedRouta
 	learningPath: LearningPath;
 	learningPathLoaded: Promise<unknown>;
 	breadcrumbLinkEntries: LinkEntry[] = [];
-	pdfTemplatesPromise: Promise<unknown>;
+	pdfTemplatesPromise: Promise<void>;
 	pdfTemplates: ApiPDFTemplate[];
-	selectPDFTemplateOptions: FormFieldSelectOption[] = [];
+	selectPDFTemplateOptions: Array<{ label: string; value: string | null }> = [];
 
 	@ViewChild('formElem')
 	formElem: ElementRef<HTMLFormElement>;
@@ -163,13 +163,10 @@ export class LearningPathEditPDFTemplateComponent extends BaseAuthenticatedRouta
 	}
 
 	getPDFTemplatesForIssuerApi(issuerSlug) {
-		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(issuerSlug)
-			.then(
-				(pdfTemplates) =>
-					(this.pdfTemplates = pdfTemplates.sort(
-						(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
-					)),
+		this.pdfTemplatesPromise = this.pdfTemplateManager.getPDFTemplatesForIssuer(issuerSlug).then((pdfTemplates) => {
+			this.pdfTemplates = pdfTemplates.sort(
+				(a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
 			);
+		});
 	}
 }

--- a/src/app/issuer/components/pdftemplate-edit-form/pdftemplate-edit-form.component.html
+++ b/src/app/issuer/components/pdftemplate-edit-form/pdftemplate-edit-form.component.html
@@ -288,6 +288,7 @@
 						[control]="pdfTemplateForm.rawControlMap.name"
 						[autofocus]="true"
 						[sublabelRight]="'(max. 50 ' + ('General.characters' | translate) + ')'"
+						[errorMessage]="{ required: 'PDFTemplate.nameRequiredError' | translate }"
 					></oeb-input>
 				</section>
 

--- a/src/app/issuer/models/badgeclass-api.model.ts
+++ b/src/app/issuer/models/badgeclass-api.model.ts
@@ -40,6 +40,7 @@ export interface ApiBadgeClassForCreation {
 	expiration?: number; // in days
 	copy_permissions?: BadgeClassCopyPermissions[];
 	criteria?: Array<{ name: string; description: string }>;
+	pdf_template?: string | null;
 }
 
 export interface ApiBadgeClassAlignment {

--- a/src/app/issuer/models/badgeclass.model.ts
+++ b/src/app/issuer/models/badgeclass.model.ts
@@ -186,10 +186,10 @@ export class BadgeClass extends ManagedEntity<ApiBadgeClass, BadgeClassRef> {
 	}
 
 	get pdfTemplate(): string | null {
-		return (this.apiModel as any).pdf_template ?? null;
+		return this.apiModel.pdf_template ?? null;
 	}
 	set pdfTemplate(value: string | null) {
-		(this.apiModel as any).pdf_template = value;
+		this.apiModel.pdf_template = value;
 	}
 
 	canCopy(key: BadgeClassCopyPermissions) {

--- a/src/app/issuer/models/badgeclass.model.ts
+++ b/src/app/issuer/models/badgeclass.model.ts
@@ -185,6 +185,13 @@ export class BadgeClass extends ManagedEntity<ApiBadgeClass, BadgeClassRef> {
 		this.apiModel.copy_permissions = permissions;
 	}
 
+	get pdfTemplate(): string | null {
+		return (this.apiModel as any).pdf_template ?? null;
+	}
+	set pdfTemplate(value: string | null) {
+		(this.apiModel as any).pdf_template = value;
+	}
+
 	canCopy(key: BadgeClassCopyPermissions) {
 		return this.copyPermissions.indexOf(key) !== -1;
 	}

--- a/src/app/issuer/models/badgeinstance-api.model.ts
+++ b/src/app/issuer/models/badgeinstance-api.model.ts
@@ -42,7 +42,6 @@ export interface ApiBadgeInstanceForCreation {
 	activity_city?: string;
 	activity_online?: boolean;
 	name?: string;
-	pdftemplate?: string;
 	course_url?: string;
 }
 
@@ -85,7 +84,6 @@ export interface BadgeInstanceBatchAssertion {
 	extensions?: object;
 	activity_start_date?: string;
 	activity_end_date?: string;
-	pdftemplate?: string;
 	activity_zip?: string;
 	activity_city?: string;
 	activity_online?: boolean;

--- a/src/app/issuer/models/qrcode-api.model.ts
+++ b/src/app/issuer/models/qrcode-api.model.ts
@@ -17,7 +17,6 @@ export interface ApiQRCode {
 	issuer_id?: string;
 	request_count?: number;
 	notifications?: boolean;
-	pdftemplate?: string;
 	course_url?: string;
 }
 

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1200,6 +1200,7 @@
 		"selectAlignment": "Bitte wähle eine Textausrichtung",
 		"selectFormat": "Bitte wähle ein PDF Format",
 		"titleLabel": "Name der Vorlage",
+		"nameRequiredError": "Bitte Name der Vorlage eingeben",
 		"variableContentNote": "Hinweis: Echte Badge-Inhalte variieren in der Länge und können von der Vorschau abweichen. Falls ein vergebenes Badge-PDF einmal nicht optimal aussieht, melde dich gerne bei uns.",
 		"openEditDialogTitle": "Möchtest du wirklich Änderungen vornehmen?",
 		"openEditDialogText": "Wenn Lernende ihr erhaltenes Badge-PDF neu von OEB herunterladen, enthält es die Änderungen.<br><br><span class='tw-font-bold'>Bearbeite die Vorlage daher nur, wenn sich grundlegende Informationen geändert haben – zum Beispiel euer Logo oder eure Adresse.</span><br><br>Wenn sich der Zeitraum auf dem Hintergrund ändert (z. B. Jahr, Semester), erstelle eine neue Vorlage.",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1157,6 +1157,7 @@
 		"selectAlignment": "Please select a text alignment",
 		"selectFormat": "Please select a PDF format",
 		"titleLabel": "Name of the template",
+		"nameRequiredError": "Please enter the template name",
 		"variableContentNote": "Note: Real badge content varies in length and may differ from the preview. If a badge PDF doesn't look the best, please contact us.",
 		"openEditDialogTitle": "Do you really want to make changes?",
 		"openEditDialogText": "When learners download their received badge PDF from OEB, it contains the changes.<br><br><span class='tw-font-bold'>Therefore, only edit the template if basic information has changed, such as your logo or address.</span><br><br>If the time period changes on the background (e.g., year, semester), create a new template.",


### PR DESCRIPTION
Closes #2111 

 **Changes:**
 
- `BadgeClass` model gains a `pdfTemplate` getter/setter; `pdf_template` removed from assertion API types
- Badge creation wizard and edit form: PDF template dropdown added to the last step ("Optional Details", previously "Tags")
 - Edit-issued page: PDF template dropdown added so issuers can update the template retroactively
 - Bulk award and QR code forms: PDF template dropdown removed
 - PDF template name field: fixed mixed-language validation error on non-German UI