### PR TITLE
feat(dashboard): add badges-by-tag donut chart to badge analysis

### DIFF
--- a/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.html
+++ b/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.html
@@ -3,19 +3,26 @@
 	<div
 		class="badge-pie-chart"
 		[class.badge-pie-chart--left]="labelPosition === 'left'"
+		[class.badge-pie-chart--right]="labelPosition === 'right'"
 		[class.badge-pie-chart--bottom]="labelPosition === 'bottom'"
 	>
 		<!-- Legend (configurable position) - shows all segments including 0% -->
 		<div
 			class="badge-pie-chart__legend"
 			[class.badge-pie-chart__legend--left]="labelPosition === 'left'"
+			[class.badge-pie-chart__legend--right]="labelPosition === 'right'"
 			[class.badge-pie-chart__legend--bottom]="labelPosition === 'bottom'"
 		>
 			@for (segment of allSegments; track segment.id) {
 				<div
 					class="badge-pie-chart__legend-item"
 					[class.badge-pie-chart__legend-item--clickable]="labelsClickable"
+					[style.opacity]="getSegmentOpacity(segment)"
 					(click)="onLabelClick(segment)"
+					(mouseenter)="onSegmentHover(segment.id)"
+					(mouseleave)="onSegmentHover(null)"
+					(focus)="onSegmentHover(segment.id)"
+					(blur)="onSegmentHover(null)"
 					[attr.role]="labelsClickable ? 'button' : null"
 					[attr.tabindex]="labelsClickable ? 0 : null"
 					(keydown.enter)="onLabelClick(segment)"
@@ -62,54 +69,57 @@
 						fill="none"
 						[attr.stroke]="segment.color"
 						stroke-width="47"
+						[style.opacity]="getSegmentOpacity(segment)"
 						[attr.stroke-dasharray]="getStrokeDasharrayWithGap(segment.percentage)"
 						[attr.stroke-dashoffset]="getStrokeDashoffsetWithGap(i)"
 					></circle>
 				}
 				<!-- Border arcs for each segment (outer, inner, and radial lines) -->
 				@for (segment of allSegments; let i = $index; track segment.id) {
-					<!-- Outer arc border -->
-					<circle
-						cx="153.5"
-						cy="153.5"
-						r="152"
-						fill="none"
-						[attr.stroke]="segment.borderColor"
-						stroke-width="3"
-						[attr.stroke-dasharray]="getStrokeDasharrayWithGap(segment.percentage, 152)"
-						[attr.stroke-dashoffset]="getStrokeDashoffsetWithGap(i, 152)"
-					></circle>
-					<!-- Inner arc border -->
-					<circle
-						cx="153.5"
-						cy="153.5"
-						r="105"
-						fill="none"
-						[attr.stroke]="segment.borderColor"
-						stroke-width="3"
-						[attr.stroke-dasharray]="getStrokeDasharrayWithGap(segment.percentage, 105)"
-						[attr.stroke-dashoffset]="getStrokeDashoffsetWithGap(i, 105)"
-					></circle>
-					<!-- Start radial line -->
-					<line
-						[attr.x1]="getRadialLineCoord(i, 105, 'x')"
-						[attr.y1]="getRadialLineCoord(i, 105, 'y')"
-						[attr.x2]="getRadialLineCoord(i, 152, 'x')"
-						[attr.y2]="getRadialLineCoord(i, 152, 'y')"
-						[attr.stroke]="segment.borderColor"
-						stroke-width="3"
-						stroke-linecap="round"
-					></line>
-					<!-- End radial line -->
-					<line
-						[attr.x1]="getRadialLineCoord(i, 105, 'x', true)"
-						[attr.y1]="getRadialLineCoord(i, 105, 'y', true)"
-						[attr.x2]="getRadialLineCoord(i, 152, 'x', true)"
-						[attr.y2]="getRadialLineCoord(i, 152, 'y', true)"
-						[attr.stroke]="segment.borderColor"
-						stroke-width="3"
-						stroke-linecap="round"
-					></line>
+					<g [style.opacity]="getSegmentOpacity(segment)">
+						<!-- Outer arc border -->
+						<circle
+							cx="153.5"
+							cy="153.5"
+							r="152"
+							fill="none"
+							[attr.stroke]="segment.borderColor"
+							stroke-width="3"
+							[attr.stroke-dasharray]="getStrokeDasharrayWithGap(segment.percentage, 152)"
+							[attr.stroke-dashoffset]="getStrokeDashoffsetWithGap(i, 152)"
+						></circle>
+						<!-- Inner arc border -->
+						<circle
+							cx="153.5"
+							cy="153.5"
+							r="105"
+							fill="none"
+							[attr.stroke]="segment.borderColor"
+							stroke-width="3"
+							[attr.stroke-dasharray]="getStrokeDasharrayWithGap(segment.percentage, 105)"
+							[attr.stroke-dashoffset]="getStrokeDashoffsetWithGap(i, 105)"
+						></circle>
+						<!-- Start radial line -->
+						<line
+							[attr.x1]="getRadialLineCoord(i, 105, 'x')"
+							[attr.y1]="getRadialLineCoord(i, 105, 'y')"
+							[attr.x2]="getRadialLineCoord(i, 152, 'x')"
+							[attr.y2]="getRadialLineCoord(i, 152, 'y')"
+							[attr.stroke]="segment.borderColor"
+							stroke-width="3"
+							stroke-linecap="round"
+						></line>
+						<!-- End radial line -->
+						<line
+							[attr.x1]="getRadialLineCoord(i, 105, 'x', true)"
+							[attr.y1]="getRadialLineCoord(i, 105, 'y', true)"
+							[attr.x2]="getRadialLineCoord(i, 152, 'x', true)"
+							[attr.y2]="getRadialLineCoord(i, 152, 'y', true)"
+							[attr.stroke]="segment.borderColor"
+							stroke-width="3"
+							stroke-linecap="round"
+						></line>
+					</g>
 				}
 			</svg>
 		</div>

--- a/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.scss
+++ b/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.scss
@@ -12,6 +12,26 @@
 		flex-direction: row;
 	}
 
+	// Layout variant: labels on right (chart left, legend right).
+	// Left-align the pair so the donut sits flush-left in wide cards, and use
+	// `order` to place the chart before the legend (legend is first in the DOM).
+	&--right {
+		flex-direction: row;
+		justify-content: flex-start;
+		gap: 48px;
+	}
+
+	&--right &__legend {
+		order: 1;
+	}
+
+	// Single-line legend rows for the right layout: "Label 8 (25%)"
+	&--right &__legend-text {
+		flex-direction: row;
+		align-items: baseline;
+		gap: 6px;
+	}
+
 	// Layout variant: labels on bottom
 	&--bottom {
 		flex-direction: column;
@@ -30,6 +50,12 @@
 			gap: 16px;
 		}
 
+		// Vertical legend (for right position)
+		&--right {
+			flex-direction: column;
+			gap: 8px;
+		}
+
 		// Horizontal legend (for bottom position)
 		&--bottom {
 			flex-direction: row;
@@ -45,7 +71,9 @@
 		gap: 12px;
 		padding: 8px;
 		border-radius: 8px;
-		transition: background-color 0.2s ease;
+		transition:
+			background-color 0.2s ease,
+			opacity 0.2s ease;
 
 		// Clickable variant
 		&--clickable {
@@ -132,6 +160,12 @@
 		height: 100%;
 		transform: rotate(-90deg);
 		overflow: visible;
+
+		circle,
+		line,
+		g {
+			transition: opacity 0.2s ease;
+		}
 	}
 
 	// ==========================================
@@ -200,7 +234,12 @@
 			flex-direction: column;
 		}
 
-		&__legend--left {
+		&--right {
+			flex-direction: column;
+		}
+
+		&__legend--left,
+		&__legend--right {
 			flex-direction: row;
 			flex-wrap: wrap;
 			justify-content: center;

--- a/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.ts
+++ b/src/app/dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component.ts
@@ -76,14 +76,27 @@ export class BadgeDistributionPieChartComponent {
 	/**
 	 * Position of the legend/labels
 	 * - 'left': Labels appear to the left of the chart
+	 * - 'right': Labels appear to the right of the chart
 	 * - 'bottom': Labels appear below the chart
 	 */
-	@Input() labelPosition: 'left' | 'bottom' = 'left';
+	@Input() labelPosition: 'left' | 'right' | 'bottom' = 'left';
+
+	/**
+	 * Maximum number of segments to render in the chart and legend.
+	 * Defaults to 3 to preserve the original behavior for existing callers.
+	 */
+	@Input() maxSegments: number = 3;
 
 	/**
 	 * Whether labels are clickable (shows arrow and hover effect)
 	 */
 	@Input() labelsClickable: boolean = false;
+
+	/**
+	 * Whether hovering a legend row highlights the matching chart segment
+	 * (and dims the others). Off by default to preserve existing callers.
+	 */
+	@Input() highlightOnHover: boolean = false;
 
 	/**
 	 * Size variant of the chart
@@ -130,17 +143,17 @@ export class BadgeDistributionPieChartComponent {
 	}
 
 	/**
-	 * All segments for legend display (including 0 count, limited to 3)
+	 * All segments for legend display (including 0 count, limited to maxSegments)
 	 */
 	get allSegments(): PieChartSegment[] {
-		return this.segments.slice(0, 3);
+		return this.segments.slice(0, this.maxSegments);
 	}
 
 	/**
 	 * Filter segments to only show those with count > 0 for the pie chart
 	 */
 	get activeSegments(): PieChartSegment[] {
-		return this.segments.filter((s) => s.count > 0).slice(0, 3);
+		return this.segments.filter((s) => s.count > 0).slice(0, this.maxSegments);
 	}
 
 	/**
@@ -228,5 +241,29 @@ export class BadgeDistributionPieChartComponent {
 		if (this.labelsClickable) {
 			this.labelClick.emit(segment);
 		}
+	}
+
+	/** Id of the segment currently hovered via its legend row (null = none). */
+	hoveredSegmentId: string | null = null;
+
+	/**
+	 * Track the hovered legend row so the chart can emphasize it.
+	 */
+	onSegmentHover(id: string | null): void {
+		if (this.highlightOnHover) {
+			this.hoveredSegmentId = id;
+		}
+	}
+
+	/**
+	 * Opacity for a segment (fill arc and legend row) given the current hover.
+	 * Returns 1 when hover highlighting is off or nothing is hovered; otherwise
+	 * dims every segment except the hovered one.
+	 */
+	getSegmentOpacity(segment: PieChartSegment): number {
+		if (!this.highlightOnHover || this.hoveredSegmentId === null) {
+			return 1;
+		}
+		return segment.id === this.hoveredSegmentId ? 1 : 0.3;
 	}
 }

--- a/src/app/dashboard/models/dashboard-api.model.ts
+++ b/src/app/dashboard/models/dashboard-api.model.ts
@@ -556,6 +556,89 @@ export interface BadgeTypeStatsExtended {
 }
 
 // ==========================================
+// Network Tag Distribution Endpoint Types
+// ==========================================
+
+/**
+ * Category of a tag distribution segment.
+ * - 'tag': one of the top tags
+ * - 'others': aggregation of all tags ranked 6th and below ("Sonstige")
+ * - 'notSpecified': badges whose badge class has no tags ("Keine Angabe")
+ */
+export type TagDistributionCategory = 'tag' | 'others' | 'notSpecified';
+
+/**
+ * Response from GET /v1/issuer/dashboard/{issuerSlug}/tag-distribution
+ */
+export interface NetworkTagDistributionResponse {
+	metadata?: {
+		totalBadges: number;
+		year: number | null;
+		lastUpdated: string;
+	};
+	distribution: NetworkTagDistributionEntry[];
+}
+
+export interface NetworkTagDistributionEntry {
+	/** Stable id: normalized tag key, 'others' or 'notSpecified' */
+	id: string;
+	/** Display label (server default label for others/notSpecified is overridden via i18n) */
+	label: string;
+	count: number;
+	/** Percentage of total badges (may exceed 100 across segments due to multi-tag badges) */
+	percentage: number;
+	category: TagDistributionCategory;
+}
+
+/**
+ * Fill/border color pair for a tag distribution segment.
+ */
+export interface TagSegmentColor {
+	color: string;
+	borderColor: string;
+}
+
+/**
+ * Ordered fill/border colors for the top tags, using the OEB purple scale
+ * (light -> dark) defined in src/styles/oeb/oeb_styles.scss.
+ */
+export const TAG_SEGMENT_COLORS: TagSegmentColor[] = [
+	{ color: '#e2daf3', borderColor: '#cbbdea' }, // purple-100 / purple-200
+	{ color: '#cbbdea', borderColor: '#b4a1e1' }, // purple-200 / purple-300
+	{ color: '#b4a1e1', borderColor: '#9d84d8' }, // purple-300 / purple-400
+	{ color: '#9d84d8', borderColor: '#8567cf' }, // purple-400 / purple-500
+	{ color: '#8567cf', borderColor: '#6c4ac7' }, // purple-500 / purple-600
+];
+
+/** Color for the aggregated "Sonstige" / "Others" segment */
+export const TAG_SEGMENT_OTHERS_COLOR: TagSegmentColor = {
+	color: '#e0e0e0',
+	borderColor: '#bdbdbd',
+};
+
+/** Color for the standalone "Keine Angabe" / "Not Specified" segment */
+export const TAG_SEGMENT_NOT_SPECIFIED_COLOR: TagSegmentColor = {
+	color: '#432b88', // purple-900
+	borderColor: '#3d2979', // purple-950
+};
+
+/**
+ * Resolve the fill/border color for a tag distribution segment.
+ *
+ * @param index - Index of the segment within the top-tag list (0-based)
+ * @param category - Segment category
+ */
+export function getTagSegmentColor(index: number, category: TagDistributionCategory): TagSegmentColor {
+	if (category === 'others') {
+		return TAG_SEGMENT_OTHERS_COLOR;
+	}
+	if (category === 'notSpecified') {
+		return TAG_SEGMENT_NOT_SPECIFIED_COLOR;
+	}
+	return TAG_SEGMENT_COLORS[index % TAG_SEGMENT_COLORS.length];
+}
+
+// ==========================================
 // Network Delivery Method Distribution Endpoint Types
 // ==========================================
 

--- a/src/app/dashboard/services/dashboard-api.service.ts
+++ b/src/app/dashboard/services/dashboard-api.service.ts
@@ -15,6 +15,7 @@ import {
 	NetworkBadgeAwardsTimelineResponse,
 	NetworkBadgeAwardsTimelineParams,
 	NetworkBadgeTypeDistributionResponse,
+	NetworkTagDistributionResponse,
 	NetworkDeliveryMethodDistributionResponse,
 	DashboardRecentBadgeAwardsResponse,
 	DashboardRecentBadgeAwardsParams,
@@ -563,6 +564,43 @@ export class DashboardApiService extends BaseHttpApiService {
 						error,
 					);
 					return throwError(() => this.mapError(error, 'getBadgeTypeDistribution'));
+				}),
+			);
+	}
+
+	// ==========================================
+	// Network Tag Distribution Endpoint
+	// ==========================================
+
+	/**
+	 * Get Badge Distribution by Tag
+	 *
+	 * Returns the distribution of issued badges by tag (Themenbereich) for
+	 * pie/donut chart visualization. Returns the top 5 tags plus optional
+	 * "others" and "notSpecified" segments.
+	 *
+	 * @param issuerSlug - Issuer or Network identifier
+	 * @param year - Optional year filter
+	 * @returns Observable with tag distribution data
+	 */
+	getTagDistribution(issuerSlug: string, year?: number): Observable<NetworkTagDistributionResponse> {
+		let params = new HttpParams();
+		if (year) {
+			params = params.set('year', year.toString());
+		}
+
+		return this.http
+			.get<NetworkTagDistributionResponse>(this.buildDashboardApiUrl(issuerSlug, 'tag-distribution'), {
+				params,
+				withCredentials: true,
+			})
+			.pipe(
+				catchError((error) => {
+					console.error(
+						`[DashboardApiService] GET /issuer/dashboard/${issuerSlug}/tag-distribution failed:`,
+						error,
+					);
+					return throwError(() => this.mapError(error, 'getTagDistribution'));
 				}),
 			);
 	}

--- a/src/app/issuer/components/network-badge-analysis/network-badge-analysis.component.html
+++ b/src/app/issuer/components/network-badge-analysis/network-badge-analysis.component.html
@@ -501,6 +501,35 @@
 									<app-dashboard-top-badges [top3Badges]="top3Badges"> </app-dashboard-top-badges>
 								</div>
 							</div>
+
+							<div class="tw-grid tw-grid-cols-1 lg:tw-grid-cols-3 tw-gap-6 tw-mt-6">
+								<div
+									class="lg:tw-col-span-2 tw-bg-white tw-rounded-lg tw-p-6 tw-border-solid"
+									style="border-width: 1px; border-color: var(--color-purple)"
+								>
+									<h3 class="tw-text-xl tw-font-semibold tw-mb-6" style="color: var(--color-black)">
+										{{ 'Dashboard.badgeDistributionByTags' | translate }}
+									</h3>
+
+									@if (hasTagData) {
+										<app-badge-distribution-pie-chart
+											[segments]="tagStats"
+											[total]="tagTotalBadges"
+											totalLabel="Network.Dashboard.unit.badges"
+											labelPosition="right"
+											[maxSegments]="7"
+											[highlightOnHover]="true"
+										>
+										</app-badge-distribution-pie-chart>
+									} @else {
+										<div
+											class="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-min-h-48 tw-text-gray-500"
+										>
+											{{ 'Dashboard.noDataAvailable' | translate }}
+										</div>
+									}
+								</div>
+							</div>
 						</div>
 					</div>
 

--- a/src/app/issuer/components/network-badge-analysis/network-badge-analysis.component.ts
+++ b/src/app/issuer/components/network-badge-analysis/network-badge-analysis.component.ts
@@ -79,8 +79,14 @@ import {
 	getBadgeRankDisplayConfig,
 	getBadgeTypeDisplayConfig,
 	getCompetencyAreaDisplayConfig,
+	getTagSegmentColor,
 	BadgeTypeStatsExtended,
+	NetworkTagDistributionEntry,
 } from '../../../dashboard/models/dashboard-api.model';
+import {
+	BadgeDistributionPieChartComponent,
+	PieChartSegment,
+} from '../../../dashboard/components/badge-distribution-pie-chart/badge-distribution-pie-chart.component';
 import { IssuerManager } from '~/issuer/services/issuer-manager.service';
 import { Issuer } from '~/issuer/models/issuer.model';
 
@@ -160,6 +166,7 @@ export interface MonthlyBadgeData {
 		OebTabsComponent,
 		BadgesYearlyLineChartComponent,
 		HorizontalBarChartComponent,
+		BadgeDistributionPieChartComponent,
 		...HlmTableImports,
 		...OebTableImports,
 		HlmIconModule,
@@ -221,8 +228,24 @@ export class NetworkBadgeAnalysisComponent extends BaseAuthenticatedRoutableComp
 
 	badgeTypeStats: BadgeTypeStatsExtended[] = [];
 
+	tagStats: PieChartSegment[] = [];
+
 	get totalBadges(): number {
 		return this.badgeTypeStats.reduce((sum, stat) => sum + stat.count, 0);
+	}
+
+	/**
+	 * Total badges represented by the tag distribution (shown in the donut center).
+	 * Uses the endpoint's total (via notSpecified + tag counts) rather than summing
+	 * segments, since multi-tag badges make segment counts overlap.
+	 */
+	tagTotalBadges: number = 0;
+
+	/**
+	 * Check if the tag distribution chart has any data.
+	 */
+	get hasTagData(): boolean {
+		return this.tagStats.some((stat) => stat.count > 0);
 	}
 
 	/**
@@ -471,6 +494,12 @@ export class NetworkBadgeAnalysisComponent extends BaseAuthenticatedRoutableComp
 					return of({ distribution: [] });
 				}),
 			),
+			tagDistribution: this.networkDashboardApi.getTagDistribution(this.networkSlug).pipe(
+				catchError((error) => {
+					console.error('[NETWORK-BADGE-ANALYSIS] Error loading tag distribution:', error);
+					return of({ distribution: [] });
+				}),
+			),
 			recentBadgeAwards: this.networkDashboardApi.getRecentBadgeAwards(this.networkSlug, { limit: 50 }).pipe(
 				catchError((error) => {
 					console.error('[NETWORK-BADGE-ANALYSIS] Error loading recent badge awards:', error);
@@ -491,6 +520,7 @@ export class NetworkBadgeAnalysisComponent extends BaseAuthenticatedRoutableComp
 					topBadges,
 					badgeAwardsTimeline,
 					badgeTypeDistribution,
+					tagDistribution,
 					recentBadgeAwards,
 					deliveryMethodDistribution,
 				}) => {
@@ -522,6 +552,14 @@ export class NetworkBadgeAnalysisComponent extends BaseAuthenticatedRoutableComp
 					if (badgeTypeDistribution?.distribution && badgeTypeDistribution.distribution.length > 0) {
 						this.badgeTypeStats = this.transformBadgeTypeDistribution(badgeTypeDistribution.distribution);
 					}
+
+					if (tagDistribution?.distribution && tagDistribution.distribution.length > 0) {
+						this.tagStats = this.transformTagDistribution(tagDistribution.distribution);
+					} else {
+						this.tagStats = [];
+					}
+					this.tagTotalBadges =
+						'metadata' in tagDistribution ? (tagDistribution.metadata?.totalBadges ?? 0) : 0;
 
 					if (recentBadgeAwards?.awards && recentBadgeAwards.awards.length > 0) {
 						this.monthlyBadges = this.transformRecentBadgeAwardsToMonthlyBadges(recentBadgeAwards.awards);
@@ -653,6 +691,37 @@ export class NetworkBadgeAnalysisComponent extends BaseAuthenticatedRoutableComp
 				percentage: entry.percentage,
 				color: displayConfig.color,
 				borderColor: displayConfig.borderColor,
+			};
+		});
+	}
+
+	/**
+	 * Transform tag distribution from API to PieChartSegment[] for the donut chart.
+	 * Resolves colors from the purple palette and localizes the labels for the
+	 * "others" and "notSpecified" categories.
+	 */
+	private transformTagDistribution(distribution: NetworkTagDistributionEntry[]): PieChartSegment[] {
+		let tagIndex = 0;
+		return distribution.map((entry) => {
+			const color = getTagSegmentColor(tagIndex, entry.category);
+			if (entry.category === 'tag') {
+				tagIndex++;
+			}
+
+			let label = entry.label;
+			if (entry.category === 'others') {
+				label = this.translate.instant('Dashboard.tags.others');
+			} else if (entry.category === 'notSpecified') {
+				label = this.translate.instant('Dashboard.tags.notSpecified');
+			}
+
+			return {
+				id: entry.id,
+				label,
+				count: entry.count,
+				percentage: entry.percentage,
+				color: color.color,
+				borderColor: color.borderColor,
 			};
 		});
 	}

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1434,6 +1434,11 @@
 		"total": "Gesamt",
 		"badgesAwarded": "Badges vergeben",
 		"badgeDistributionByType": "Vergebene Badges nach Typ",
+		"badgeDistributionByTags": "Badge-Vergaben nach Themenbereich (Tags)",
+		"tags": {
+			"others": "Sonstige",
+			"notSpecified": "Keine Angabe"
+		},
 		"badgesAwardedInYear": "Vergebene Badges im Jahr",
 		"allMonths": "Alle Monate",
 		"zipCode": "PLZ",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1391,6 +1391,11 @@
 		"total": "Total",
 		"badgesAwarded": "Badges awarded",
 		"badgeDistributionByType": "Badges Awarded by Type",
+		"badgeDistributionByTags": "Badges Awarded by Tag",
+		"tags": {
+			"others": "Others",
+			"notSpecified": "Not Specified"
+		},
 		"badgesAwardedInYear": "Badges Awarded in Year",
 		"allMonths": "All Months",
 		"zipCode": "ZIP Code",


### PR DESCRIPTION
## Summary

Adds a **"Badges by Tag"** (Badge-Vergaben nach Themenbereich) donut chart to the Badge Analysis section of the institution and network dashboards, mirroring the existing "Badges by Type" chart.

Closes #2082.

## What's included
- Reuses the existing `badge-distribution-pie-chart` component, generalized with:
  - a `maxSegments` input (default 3, so existing donuts are unchanged) to allow the 7-segment tag chart
  - a `right` legend layout (chart left / legend right, single-line rows) matching the Figma
  - an optional `highlightOnHover` mode that emphasizes the hovered segment and dims the rest
- `NetworkTagDistribution` model types, a purple-scale segment palette (`getTagSegmentColor`), and the `getTagDistribution` API call
- Localized `Sonstige` / `Keine Angabe` segment labels (de/en)

Top 5 tags by badge count (ties broken alphabetically), remaining tags aggregated into **Sonstige**, and untagged badges shown as a standalone **Keine Angabe** segment.

## Backend
This needs the new `tag-distribution` endpoint, added in the dashboard plugin repo  in a companion PR.

## Testing
- `ng build` and `npm run lint` pass
- Verified end-to-end locally against seeded tagged badges (correct ranking, tie-break, Sonstige/Keine Angabe segments, hover highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)