### PR TITLE
fix(learningpath): save changes when editing an existing learning path

### DIFF
--- a/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
+++ b/src/app/issuer/components/learningpath-edit-form/learningpath-edit-form.component.ts
@@ -885,7 +885,11 @@ export class LearningPathEditFormComponent
 	getAggregatedCompetencies(competencyExtensionContextUrl: string) {
 		const aggregated = new Map<string, any>();
 		for (const badge of this.selectedBadges) {
-			const extensions = badge.extension as Record<string, any>;
+			// selectedBadges may hold BadgeClass instances (creation flow, exposes the
+			// `.extension` getter) or raw serialized badge dicts from an existing
+			// learning path (edit flow, `.extensions`). Support both shapes and guard
+			// against badges without any extensions so onSubmit never throws.
+			const extensions = (badge.extension ?? (badge as any).extensions ?? {}) as Record<string, any>;
 			const competencies: any[] = extensions['extensions:CompetencyExtension'] || [];
 			for (const competency of competencies) {
 				const key = competency.framework_identifier || `${competency.framework}:${competency.name}`;


### PR DESCRIPTION
## Problem

Editing an existing learning path (e.g. via the Unlock/activate flow) and clicking **Save Changes** silently did nothing — no save request, no error message.

## Root cause

In `getAggregatedCompetencies()`, the method iterated `this.selectedBadges` and read `badge.extension` (singular). That getter only exists on `BadgeClass` model instances. In edit mode, `initFormFromExisting()` sets `selectedBadges = lp.badges.map(b => b.badge)`, where each `b.badge` is a raw serialized dict from the server's `BadgeClassSerializerV1` — extensions there live under the key `extensions` (plural), and there is no `.extension` getter. So `badge.extension` was `undefined`, and `extensions['extensions:CompetencyExtension']` threw a `TypeError`.

Because `onSubmit()`'s existing-LP branch has no `try/catch` (unlike the creation branch), the exception propagated, `savePromise` was never set, and save never emitted → the button appeared to do nothing. This broke editing **any** existing learning path.

## Fix

Read `extensions` from either shape and default to `{}`:

```ts
const extensions = (badge.extension ?? (badge as any).extensions ?? {}) as Record<string, any>;
```

This stops the crash and also lets edit-mode aggregation actually pick up competencies from the raw dicts' `extensions` key.

## Verification

- `npm run typecheck` passes the ratchet (no new type errors).
- `npm run lint` passes.
- Reproduced locally against a Dockerised badgr-server: created an active learning path composed of two other active micro-degrees, opened the edit form, ticked "Unlock learning path for use", and confirmed **Save Changes** now issues the save request instead of silently no-opping. The original `TypeError: Cannot read properties of undefined (reading 'extensions:CompetencyExtension')` is gone from the console.

## Follow-ups (not in this PR)

1. Wrap `onSubmit()`'s existing-LP branch in `try/catch` and surface errors via `messageService`, so failures stop presenting as "nothing happens".
2. The badge picker template (`learningpath-edit-form.component.html:225`) reads `badge.extension['extensions:CategoryExtension'].Category` with no null guard and crashes for any badge lacking that extension — a separate pre-existing bug worth its own fix.
3. In edit mode, `studyLoad` starts at 0 and is only updated by `checkboxChange`, so a plain edit-and-save may write `StudyLoad: 0` to the participation badge — verify separately.
