### PR TITLE
fix(pdftemplate): network micro degree Edit PDF button & partner badge templates

### DIFF
--- a/src/app/common/components/learningpath-detail/oeb-learning-path.component.html
+++ b/src/app/common/components/learningpath-detail/oeb-learning-path.component.html
@@ -103,7 +103,6 @@
 							}
 
 							@if (
-								!issuer.is_network &&
 								learningPath.activated &&
 								pdfTemplateManager.pdfEditorAvailable() &&
 								(!issuer?.quotas || issuer?.quotas?.quotas['PDFEDITOR'].quota)

--- a/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.component.html
+++ b/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.component.html
@@ -33,7 +33,7 @@
 							@if (issuer?.currentUserStaffMember?.canEditBadge) {
 								<oeb-button
 									class="tw-whitespace-nowrap tw-flex-grow"
-									[routerLink]="['/issuer/issuers', issuerSlug]"
+									[routerLink]="['/issuer/issuers', templateOwnerSlug]"
 									fragment="pdf-templates"
 									[text]="'PDFTemplate.createCustomPDFTemplate' | translate"
 									width="full_width"

--- a/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
+++ b/src/app/issuer/components/badgeclass-edit-issued/badgeclass-edit-issued.ts
@@ -137,17 +137,26 @@ export class BadgeClassEditIssuedComponent extends BaseAuthenticatedRoutableComp
 		this.loadPDFTemplates();
 	}
 
-	loadPDFTemplates() {
+	/**
+	 * A partner badge (shared into a network) may only use that network's PDF
+	 * templates — not the institution's. Ordinary badges use their own issuer.
+	 */
+	get templateOwnerSlug(): string {
+		return this.badgeClass?.sharedOnNetwork?.slug ?? this.issuerSlug;
+	}
+
+	async loadPDFTemplates() {
+		// Wait for the badge so we know whether it is shared on a network before
+		// deciding which issuer's PDF templates to offer.
+		await this.badgeClassLoaded;
 		this.pdfTemplatesPromise = this.pdfTemplateManager
-			.getPDFTemplatesForIssuer(this.issuerSlug)
-			.then(async (pdfTemplates) => {
+			.getPDFTemplatesForIssuer(this.templateOwnerSlug)
+			.then((pdfTemplates) => {
 				this.pdfTemplates = pdfTemplates.sort((a, b) => a.name.localeCompare(b.name));
 				this.selectPDFTemplateOptions = [
 					{ label: this.translate.instant('PDFTemplate.oebDesign'), value: null },
 					...this.pdfTemplates.map((t) => ({ label: t.name, value: t.slug })),
 				];
-				// Ensure badge class has loaded so the form value is set before we re-trigger writeValue.
-				await this.badgeClassLoaded;
 				const ctrl = this.badgeClassForm.rawControl.controls['pdf_template'];
 				const savedValue = ctrl.value;
 				setTimeout(() => ctrl.setValue(savedValue, { emitEvent: false }), 0);

--- a/src/app/issuer/components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component.ts
+++ b/src/app/issuer/components/learningpath-edit-pdftemplate/learningpath-edit-pdftemplate.component.ts
@@ -6,6 +6,7 @@ import { BaseAuthenticatedRoutableComponent } from '../../../common/pages/base-a
 import { SessionService } from '../../../common/services/session.service';
 import { MessageService } from '../../../common/services/message.service';
 import { Issuer } from '../../models/issuer.model';
+import { Network } from '~/issuer/network.model';
 import { IssuerManager } from '../../services/issuer-manager.service';
 import { BadgrApiFailure } from '../../../common/services/api-failure';
 import { LearningPath } from '~/issuer/models/learningpath.model';
@@ -49,7 +50,7 @@ export class LearningPathEditPDFTemplateComponent extends BaseAuthenticatedRouta
 
 	issuerSlug: string;
 	learningPathSlug: string;
-	issuer: Issuer;
+	issuer: Issuer | Network;
 	issuerLoaded: Promise<unknown>;
 	learningPath: LearningPath;
 	learningPathLoaded: Promise<unknown>;
@@ -100,7 +101,7 @@ export class LearningPathEditPDFTemplateComponent extends BaseAuthenticatedRouta
 					),
 			);
 
-		this.issuerLoaded = this.issuerManager.issuerBySlug(this.issuerSlug).then((issuer) => {
+		this.issuerLoaded = this.issuerManager.issuerOrNetworkBySlug(this.issuerSlug).then((issuer) => {
 			this.issuer = issuer;
 		});
 
@@ -126,7 +127,7 @@ export class LearningPathEditPDFTemplateComponent extends BaseAuthenticatedRouta
 
 		await this.issuerLoaded;
 
-		if (this.authService.isLoggedIn && this.issuer instanceof Issuer && this.issuer.currentUserStaffMember) {
+		if (this.authService.isLoggedIn && this.issuer.currentUserStaffMember) {
 			this.getPDFTemplatesForIssuerApi(this.issuer.slug);
 			await this.pdfTemplatesPromise;
 


### PR DESCRIPTION
Follow-up fixes to the network PDF templates feature (#2212), found while testing on develop.

## Issue 1 — "Edit PDF" button missing on network micro degrees
The button on the learning path detail page was gated on `!issuer.is_network`, hiding it for network micro degrees even though networks now support PDF templates.

- Removed the `!issuer.is_network` clause so the button shows for network learning paths (quota check still applies).
- Made the learning path PDF-template **edit page** network-aware: it previously loaded the issuer via `issuerBySlug` (which can't resolve a network) and gated the dropdown on `instanceof Issuer`. It now loads via `issuerOrNetworkBySlug`, widens the type to `Issuer | Network`, and gates on `currentUserStaffMember` (present on both models), so the network's templates populate.

## Issue 3 — Institution route offered institution templates for a partner badge
The reduced "already awarded" edit form (`badgeclass-edit-issued`) always loaded templates for the route's institution slug, so a partner badge (shared into a network) showed the institution's templates instead of the network's when opened via the institution. (The full edit form already had partner-badge logic; this one didn't.)

- Added a `templateOwnerSlug` getter (`badge.sharedOnNetwork?.slug ?? issuerSlug`), awaited the badge load before fetching templates, and pointed the "create own template" button at the same owner.

## Verification
Both fixes were driven end-to-end against a local server with Playwright:

- **#3** — Coding Basics (partner badge, Repro Test Issuer → OEB Test Network, already awarded) opened via the institution now lists only the network's templates (`OEB design`, `Network A – Certificate`, `Network A – Diploma`, `UI Test Template`) with the network template pre-selected; the institution's `Institution – Local` is gone.
- **#1** — A network micro degree now shows the "Edit PDF" button beside "Delete"; clicking it loads the network-aware edit page listing the network's templates.
- AOT build compiles clean.

Note: a separate server-side issue (institution template not cleared for badges shared before the clearing signal was deployed) is tracked separately and handled in the waffle plugin.