### PR TITLE
Staging 2026-07-27

### DIFF
--- a/src/app/components/dialog.component.spec.ts
+++ b/src/app/components/dialog.component.spec.ts
@@ -1,0 +1,102 @@
+import { Component, TemplateRef, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DIALOG_DATA } from '@angular/cdk/dialog';
+import { BrnDialogRef } from '@spartan-ng/brain/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { DialogComponent } from './dialog.component';
+
+@Component({
+	imports: [],
+	template: `
+		<ng-template #content>
+			<p class="content-probe">CONTENT</p>
+		</ng-template>
+		<ng-template #header>
+			<p class="header-probe">HEADER</p>
+		</ng-template>
+	`,
+})
+class TemplateHostComponent {
+	content = viewChild.required<TemplateRef<void>>('content');
+	header = viewChild.required<TemplateRef<void>>('header');
+}
+
+describe('app-dialog', () => {
+	let host: ComponentFixture<TemplateHostComponent>;
+
+	function renderDialog(context: Record<string, unknown>): ComponentFixture<DialogComponent> {
+		TestBed.resetTestingModule();
+		TestBed.configureTestingModule({
+			imports: [DialogComponent, TranslateModule.forRoot()],
+			providers: [
+				{ provide: DIALOG_DATA, useValue: context },
+				{ provide: BrnDialogRef, useValue: { close: () => {} } },
+			],
+		});
+		const fixture = TestBed.createComponent(DialogComponent);
+		fixture.detectChanges();
+		return fixture;
+	}
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({ imports: [TemplateHostComponent, TranslateModule.forRoot()] });
+		host = TestBed.createComponent(TemplateHostComponent);
+		host.detectChanges();
+	});
+
+	// Regression: 'info' had no branch in the template, so the dialog rendered an
+	// empty shell and the buttons inside the content template were unreachable.
+	// See issue #2226 (membership request could not be sent).
+	it('renders header and content for the info variant', () => {
+		const fixture = renderDialog({
+			variant: 'info',
+			headerTemplate: host.componentInstance.header(),
+			content: host.componentInstance.content(),
+		});
+
+		expect(fixture.nativeElement.querySelector('.header-probe')).not.toBeNull();
+		expect(fixture.nativeElement.querySelector('.content-probe')).not.toBeNull();
+	});
+
+	it('renders content next to the checkmark for the success variant', () => {
+		const fixture = renderDialog({
+			variant: 'success',
+			content: host.componentInstance.content(),
+		});
+
+		expect(fixture.nativeElement.querySelector('.checkmark')).not.toBeNull();
+		expect(fixture.nativeElement.querySelector('.content-probe')).not.toBeNull();
+	});
+
+	it('renders string content for the success variant', () => {
+		const fixture = renderDialog({ variant: 'success', content: '<span class="html-probe">DONE</span>' });
+
+		expect(fixture.nativeElement.querySelector('.html-probe')).not.toBeNull();
+	});
+
+	it('renders header and content once for the default variant', () => {
+		const fixture = renderDialog({
+			variant: 'default',
+			headerTemplate: host.componentInstance.header(),
+			content: host.componentInstance.content(),
+		});
+
+		expect(fixture.nativeElement.querySelectorAll('.header-probe').length).toBe(1);
+		expect(fixture.nativeElement.querySelectorAll('.content-probe').length).toBe(1);
+	});
+
+	it('renders content once for the danger variant', () => {
+		const fixture = renderDialog({ variant: 'danger', content: host.componentInstance.content() });
+
+		expect(fixture.nativeElement.querySelectorAll('.content-probe').length).toBe(1);
+	});
+
+	it('renders message and text for the failure variant', () => {
+		const fixture = renderDialog({ variant: 'failure', message: 'MESSAGE', text: 'TEXT' });
+
+		expect(fixture.nativeElement.textContent).toContain('MESSAGE');
+		expect(fixture.nativeElement.textContent).toContain('TEXT');
+		expect(fixture.nativeElement.querySelector('.content-probe')).toBeNull();
+	});
+});

--- a/src/app/components/dialog.component.ts
+++ b/src/app/components/dialog.component.ts
@@ -65,7 +65,9 @@ interface DialogContext {
 				</div>
 			}
 
-			@if (!context.variant || context.variant === 'default') {
+			<!-- Header and content for every variant that does not render them itself.
+			     'failure' and 'danger' have their own layout above/below. -->
+			@if (context.variant !== 'failure' && context.variant !== 'danger') {
 				@if (isTemplate(context.headerTemplate)) {
 					<ng-container
 						*ngTemplateOutlet="context.headerTemplate; context: context.templateContext || {}"


### PR DESCRIPTION
Promotes `develop` to staging.

Contains one change: #2227 (Closes #2226) — membership requests to an existing institution could not be sent.

`DialogComponent` gated its header/content outlets on the `default` variant, so the membership confirmation dialog (opened with `variant: 'info'`) rendered an empty shell. Its "Send request" button lives inside that content template, so it was never in the DOM and no request was ever sent. Content now renders for every variant except `failure` and `danger`, which lay out their own.

Also restores the lost text of two `success` dialogs (request forwarded, network invite sent).

Regression from 1f7749f5.

### Testing on staging

- My Institutions → search an existing institution → Send request: the confirmation dialog should show the question and both buttons, and confirming should deliver the request to the target institution (visible under Members → open membership requests, plus notification mail).
- Covered by the new `dialog.component.spec.ts` (6 tests across all five variants). Not yet verified end-to-end against a running backend.