### PR TITLE
fix(issuers): add guard for qrcodes public page

### DIFF
--- a/src/app/common/components/issuer/oeb-issuer-detail.component.ts
+++ b/src/app/common/components/issuer/oeb-issuer-detail.component.ts
@@ -232,7 +232,7 @@ export class OebIssuerDetailComponent implements OnInit, OnChanges {
 	archivedLearningPaths: ApiLearningPath[] = [];
 
 	private async updateResults() {
-		if (this.sessionService.isLoggedIn) {
+		if (this.sessionService.isLoggedIn && !this.public) {
 			this.requestsLoaded = Promise.all(
 				this.badges.map((b) =>
 					this.qrCodeApiService
@@ -309,7 +309,7 @@ export class OebIssuerDetailComponent implements OnInit, OnChanges {
 			}
 
 			let requestMap = new Map<string, ApiQRCode[]>();
-			if (this.sessionService.isLoggedIn && allBadgeClasses.length > 0) {
+			if (this.sessionService.isLoggedIn && !this.public && allBadgeClasses.length > 0) {
 				this.networkRequestsLoaded = Promise.all(
 					allBadgeClasses.map((badge) =>
 						this.qrCodeApiService


### PR DESCRIPTION
Fixes a bug where visiting a public issuer page while logged in triggered QR code API requests for every badge, with undefined as the issuer slug. Issuers with many badges with QR codes would see "server unavailable" due to the flood of failing requests. QR codes are an issuer-only feature and should never be fetched on the public page.