### PR TITLE
fix(competencies): retain skill  duration when re-running  ai tool

### DIFF
--- a/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
+++ b/src/app/issuer/components/badgeclass-edit-form/badgeclass-edit-form.component.ts
@@ -1122,6 +1122,16 @@ export class BadgeClassEditFormComponent
 			.getAiSkillsForIssuer(this.aiCompetenciesDescription, this.issuer.slug)
 			.then((skills) => {
 				let aiCompetencies = this.badgeClassForm.controls.aiCompetencies;
+				const savedDurations = new Map<string, { hours: number; minutes: number; studyLoad: number }>();
+				aiCompetencies.value.forEach((c, i) => {
+					if (c.selected) {
+						savedDurations.set(this.aiCompetenciesSuggestions[i].concept_uri, {
+							hours: c.hours,
+							minutes: c.minutes,
+							studyLoad: c.studyLoad,
+						});
+					}
+				});
 				const selectedAiCompetencies = aiCompetencies.value
 					.map((c, i) => (c.selected ? this.aiCompetenciesSuggestions[i] : null))
 					.filter(Boolean);
@@ -1139,9 +1149,11 @@ export class BadgeClassEditFormComponent
 				this.aiCompetenciesSuggestions.forEach((skill, i) => {
 					aiCompetencies.addFromTemplate();
 					if (selectedAiCompetencies.includes(skill)) {
+						const saved = savedDurations.get(skill.concept_uri);
 						this.badgeClassForm.controls.aiCompetencies.controls[i].setValue({
 							...this.badgeClassForm.controls.aiCompetencies.controls[i].value,
 							selected: true,
+							...(saved || {}),
 						});
 					}
 				});


### PR DESCRIPTION
## Summary
- Fixes #2260 
- When re-running the AI competency assistant with a new description, user-edited hours/minutes for previously-selected competencies were resetting to defaults (1h 0m)

## Test plan
- [ ] Set a custom duration (e.g. 3h 30m) on one or more AI-suggested competencies
- [ ] Re-run the AI assistant with a different badge description
- [ ] Confirm previously-selected competencies retain their custom durations
- [ ] Confirm unselected competencies still get the default duration (1h 0m) on fresh suggestion
- [ ] Confirm the full badge save flow still works with the retained values